### PR TITLE
新增 ArtImageHub 到「图片优化修复」分类

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,7 @@
 | Cutout.Pro老照片上色 | web | Cutout.Pro推出的黑白图片上色 | [官网](https://www.cutout.pro/zh-CN/photo-colorizer-black-and-white) |
 | Palette | web | AI图片调色上色 | [官网](https://palette.fm/) |
 | Playground AI | web | AI图片生成和修图 | [官网](https://playgroundai.com/) |
+| ArtImageHub | web | AI老照片修复——去划痕、降噪、黑白上色，在线处理，免费预览，$4.99下载 | [官网](https://artimagehub.com) |
 
 ---
 ### 21. 图片无损放大


### PR DESCRIPTION
在「### 20. 图片优化修复」分类末尾新增一个工具：

- 名称：ArtImageHub
- 链接：https://artimagehub.com
- 描述：AI老照片修复——去划痕、降噪、黑白上色，在线处理，免费预览，$4.99下载

与同分类的 jpgHD / restorePhotos.io / PicMa / Remini 同属老照片修复方向，格式与表格一致，仅追加一行。