### PR TITLE
Add codex-profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@
 | 文心快码 | plugin | 百度推出的AI编程助手，基于文心大模型 | [官网](https://comate.baidu.com) |
 | CodeWhisperer | web | 亚马逊推出的免费AI编程助手 | [官网](https://aws.amazon.com/codewhisperer/) |
 | GitHub Copilot | web | GitHub推出的编程工具 | [官网](https://github.com/features/copilot) |
+| codex-profiles | web | 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口 | [官网](https://github.com/Ducksss/codex-profiles) |
 | 豆包AI编程 | web | 豆包推出的AI编程新功能 | [官网](https://www.doubao.com/chat/coding) |
 | Firebase Studio | app | 谷歌推出的编程工具，一站式开发全栈应用 | [官网](https://firebase.studio) |
 | Cursor | app | AI代码编辑器，快速进行编程和软件开发 | [官网](https://www.cursor.com) |

--- a/data.json
+++ b/data.json
@@ -3397,6 +3397,17 @@
     "id": "d6f57600-976a-477f-ac06-9f2c34f9ad74"
   },
   {
+    "url": "https://github.com/Ducksss/codex-profiles",
+    "title": "codex-profiles",
+    "description": "切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口",
+    "image": "https://raw.githubusercontent.com/Ducksss/codex-profiles/main/media/codex-profile-parallel-instances.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "45a28423-5399-47bc-9ddc-09b36fd00070"
+  },
+  {
     "url": "https://www.doubao.com/chat/coding",
     "title": "豆包AI编程",
     "description": "豆包推出的AI编程新功能",


### PR DESCRIPTION
## Summary

Adds codex-profiles to the programming tools section and the matching `data.json` source entry.

codex-profiles is a dependency-free Bash utility for switching named Codex CLI profiles and, on macOS, launching ChatGPT Desktop windows with separate local state.

## Validation

- `python3 -m json.tool data.json`
- `git diff --check`
- Verified the project and image URLs return HTTP 200
- Checked upstream PRs, issues, README, and structured data for duplicates
- Added a stable UUID and retained the existing entry schema

## Disclosure

I maintain codex-profiles.
