### PR TITLE
Add Orkas

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,7 @@
 | GitHub Copilot | web | GitHub推出的编程工具 | [官网](https://github.com/features/copilot) |
 | codex-profiles | web | 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口 | [官网](https://github.com/Ducksss/codex-profiles) |
 | Better Agent | app | 本地AI编程代理工作区，统一运行Claude、Codex和Gemini会话，支持并行分叉、任务委派与重启恢复 | [官网](https://github.com/ofekron/better-agent) |
+| Orkas | app | 开源本地优先的多智能体桌面工作区，支持并行和串行协作 | [官网](https://orkas.ai/?source=gh_rvelamen) |
 | 豆包AI编程 | web | 豆包推出的AI编程新功能 | [官网](https://www.doubao.com/chat/coding) |
 | Firebase Studio | app | 谷歌推出的编程工具，一站式开发全栈应用 | [官网](https://firebase.studio) |
 | Cursor | app | AI代码编辑器，快速进行编程和软件开发 | [官网](https://www.cursor.com) |

--- a/data.json
+++ b/data.json
@@ -3419,6 +3419,17 @@
     "id": "3b0f1f28-7974-4bad-ba6c-1e0b0e9016f2"
   },
   {
+    "url": "https://orkas.ai/?source=gh_rvelamen",
+    "title": "Orkas",
+    "description": "开源本地优先的多智能体桌面工作区，支持并行和串行协作",
+    "image": "https://orkas.ai/res/orkas.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "7cbabe24-0a56-42f4-8d82-29064b9b62c1"
+  },
+  {
     "url": "https://www.doubao.com/chat/coding",
     "title": "豆包AI编程",
     "description": "豆包推出的AI编程新功能",


### PR DESCRIPTION
## Summary

- add Orkas to the 编程工具 section in the README
- add matching structured metadata to data.json
- classify it as an app and use the official project image

Orkas is an open-source, local-first desktop workspace for coordinating specialist AI agents.