### PR TITLE
Add WizGenerator Story Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@
 | Cubox | web | 高效的AI阅读学习助手和信息收集管理工具 | [官网](https://cubox.pro) |
 | Quivr | web | 开源的知识库搭建工具，构建你的第二大脑 | [官网](https://www.quivr.app) |
 | Remio | web | 本地优先的AI记忆和知识库，支持文件、网页、录音、邮件、消息、图片和笔记的索引与语义检索 | [官网](https://remio.ai/) |
+| WizGenerator Story Generator | web | 免费AI故事生成工具，可根据主题、类型、语气和篇幅生成故事草稿，无需注册 | [官网](https://wizgenerator.com/tools/story-generator/) |
 | Coda AI | web | 在线协作平台Coda推出的AI写作和文档助手，类似于Notion AI | [官网](https://coda.io/product/ai) |
 | 有道速读 | web | 网易有道推出的AI论文和文档阅读助手 | [官网](https://read.youdao.com) |
 | 腾讯问卷 | web | 腾讯推出的AI生成调查问卷的免费工具 | [官网](https://wj.qq.com/ai/generate.html) |

--- a/data.json
+++ b/data.json
@@ -9214,5 +9214,16 @@
     "id": "b70bbaaf-cebc-4428-b971-3ff2389afea8",
     "title": "Remio",
     "type": "web"
+  },
+  {
+    "url": "https://wizgenerator.com/tools/story-generator/",
+    "description": "免费AI故事生成工具，可根据主题、类型、语气和篇幅生成故事草稿，无需注册",
+    "image": "https://wizgenerator.com/wp-content/uploads/2024/06/cropped-WizGenerator-Icon-192x192.png",
+    "category": [
+      "文档工具"
+    ],
+    "id": "071a3525-cc75-4508-a307-7368d8727dcf",
+    "title": "WizGenerator Story Generator",
+    "type": "web"
   }
 ]


### PR DESCRIPTION
Adds WizGenerator Story Generator to the 文档工具 category in both `README.md` and `data.json`.

- Free to use
- No registration required
- Direct tool URL: https://wizgenerator.com/tools/story-generator/

The entry follows the repository’s existing format and includes only the two required catalog updates.