### PR TITLE
Add YingTu to 图像工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@
 | 可灵AI | web | 快手推出的AI图像和视频创作平台 | [官网](https://klingai.kuaishou.com) |
 | AI改图神器 | web | AI万能图片在线编辑器 | [官网](https://img.logosc.cn) |
 | Krea AI | web | 实时AI图像、视频生成和编辑平台 | [官网](https://www.krea.ai) |
+| YingTu | web | 浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比 | [官网](https://yingtu.ai/en) |
 | Photoroom | web | 在线AI图片编辑工具 | [官网](https://www.photoroom.com/zh) |
 | HairWow | web | AI发型试戴和护发建议工具，支持预览发型、发色、刘海、层次和胡须造型 | [官网](https://www.gohairwow.com) |
 | Ribbet.ai | web | 免费的多功能AI图片处理工具箱 | [官网](https://ribbet.ai/) |

--- a/data.json
+++ b/data.json
@@ -4697,6 +4697,17 @@
     "id": "afbcb903-e083-400b-998b-dbf7adadc0ce"
   },
   {
+    "url": "https://yingtu.ai/en",
+    "title": "YingTu",
+    "description": "浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比",
+    "image": "https://yingtu.ai/og-image.jpg",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "fca2ad49-bb18-43cb-a244-36d003314de9"
+  },
+  {
     "url": "https://www.photoroom.com/zh",
     "title": "Photoroom",
     "description": "在线AI图片编辑工具",


### PR DESCRIPTION
Adds YingTu to 图像工具 in README.md and data.json using the repository's current schema.

YingTu is a browser playground for testing AI image and video routes before API integration. This contribution is submitted on behalf of the YingTu project. Codex assisted with preparing the factual entry.