### PR TITLE
Add Rao Edits to image tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 | 可灵AI | web | 快手推出的AI图像和视频创作平台 | [官网](https://klingai.kuaishou.com) |
 | AI改图神器 | web | AI万能图片在线编辑器 | [官网](https://img.logosc.cn) |
 | Krea AI | web | 实时AI图像、视频生成和编辑平台 | [官网](https://www.krea.ai) |
+| Rao Edits | web | 浏览器端AI图像生成和参考图编辑工具，可用于社交视觉、产品图和创意工作流 | [官网](https://raoedits.top/) |
 | YingTu | web | 浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比 | [官网](https://yingtu.ai/en) |
 | Photoroom | web | 在线AI图片编辑工具 | [官网](https://www.photoroom.com/zh) |
 | HairWow | web | AI发型试戴和护发建议工具，支持预览发型、发色、刘海、层次和胡须造型 | [官网](https://www.gohairwow.com) |

--- a/data.json
+++ b/data.json
@@ -4697,6 +4697,17 @@
     "id": "afbcb903-e083-400b-998b-dbf7adadc0ce"
   },
   {
+    "url": "https://raoedits.top/",
+    "title": "Rao Edits",
+    "description": "浏览器端AI图像生成和参考图编辑工具，可用于社交视觉、产品图和创意工作流",
+    "image": "https://raoedits.top/preview.webp",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "131c9656-f7f9-403d-a30c-b3f0ca944e48"
+  },
+  {
     "url": "https://yingtu.ai/en",
     "title": "YingTu",
     "description": "浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比",


### PR DESCRIPTION
## Summary
- add Rao Edits to the image tools table
- add the matching machine-readable entry to `data.json`
- use the site's public preview image and a unique entry ID

## Verification
- `https://raoedits.top/` responds successfully
- `https://raoedits.top/preview.webp` is the site's declared Open Graph image
- `data.json` parses successfully and contains one Rao Edits entry

Disclosure: this is an affiliated promotional submission prepared with AI assistance. The description is limited to functionality verified on the public product interface.