### PR TITLE
Add Agent QA to 编程工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@
 | Cody | app | Sourcegraph推出的免费编程工具 | [官网](https://sourcegraph.com/cody) |
 | DevChat | plugin | 开源的支持多款大模型的AI编程助手 | [官网](https://www.devchat.ai/zh) |
 | CodiumAI | web | 免费的AI代码测试和分析工具 | [官网](https://www.codium.ai/) |
+| Agent QA | cli | 源码可用的自改进QA Agent，支持自然语言Web/移动端测试、持久测试记忆以及CLI/MCP接口 | [GitHub](https://github.com/vostride/agent-qa) |
 | Genie | app | Cosine AI推出的AI编程助手 | [官网](https://cosine.sh/genie) |
 | 码上飞 | web | AI软件开发平台，一句话自动生成端到端应用 | [官网](https://www.codeflying.net) |
 | iFlyCode | web | 科大讯飞推出的智能编程助手 | [官网](https://iflycode.xfyun.cn) |

--- a/data.json
+++ b/data.json
@@ -9258,5 +9258,16 @@
     "id": "071a3525-cc75-4508-a307-7368d8727dcf",
     "title": "WizGenerator Story Generator",
     "type": "web"
+  },
+  {
+    "url": "https://github.com/vostride/agent-qa",
+    "description": "源码可用的自改进QA Agent，支持自然语言Web/移动端测试、持久测试记忆以及CLI/MCP接口",
+    "image": "https://raw.githubusercontent.com/vostride/agent-qa/main/packages/dashboard-ui/public/favicon.svg",
+    "category": [
+      "编程工具"
+    ],
+    "id": "291006a4-8398-44bd-a6ea-b2d638f5966c",
+    "title": "Agent QA",
+    "type": "cli"
   }
 ]


### PR DESCRIPTION
## 说明

在“编程工具”中加入 [Agent QA](https://github.com/vostride/agent-qa)，并同步更新 README 表格与 `data.json`。

条目将 Agent QA 准确描述为“源码可用”的自改进 QA Agent，支持自然语言 Web/移动端测试、持久测试记忆以及 CLI/MCP 接口；没有将其标为开源软件。

## 验证

- `jq empty data.json` 通过
- Agent QA 在 JSON 中只有一个条目
- 全部 838 个 JSON ID 保持唯一
- `git diff --check` 通过

披露：我是 Agent QA 的关联维护者。当前版本采用 FSL-1.1-ALv2 源码可用许可证，两年后转换为 Apache-2.0；模型提供商可能另行收费。
