### PR TITLE
Add Agent QA to programming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@
 | 文心快码 | plugin | 百度推出的AI编程助手，基于文心大模型 | [官网](https://comate.baidu.com) |
 | CodeWhisperer | web | 亚马逊推出的免费AI编程助手 | [官网](https://aws.amazon.com/codewhisperer/) |
 | GitHub Copilot | web | GitHub推出的编程工具 | [官网](https://github.com/features/copilot) |
+| Agent QA | app | 用自然语言编写、运行和排查网页及移动应用测试，提供 CLI、仪表板和 MCP 服务器 | [官网](https://github.com/vostride/agent-qa) |
 | codex-profiles | web | 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口 | [官网](https://github.com/Ducksss/codex-profiles) |
 | Better Agent | app | 本地AI编程代理工作区，统一运行Claude、Codex和Gemini会话，支持并行分叉、任务委派与重启恢复 | [官网](https://github.com/ofekron/better-agent) |
 | Orkas | app | 开源本地优先的多智能体桌面工作区，支持并行和串行协作 | [官网](https://orkas.ai/?source=gh_rvelamen) |

--- a/data.json
+++ b/data.json
@@ -3397,6 +3397,17 @@
     "id": "d6f57600-976a-477f-ac06-9f2c34f9ad74"
   },
   {
+    "url": "https://github.com/vostride/agent-qa",
+    "title": "Agent QA",
+    "description": "用自然语言编写、运行和排查网页及移动应用测试，提供 CLI、仪表板和 MCP 服务器",
+    "image": "https://raw.githubusercontent.com/vostride/agent-qa/main/packages/dashboard-ui/public/favicon.svg",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "56adbf4a-0b6a-4baa-8f0f-52ba91a6ef20"
+  },
+  {
     "url": "https://github.com/Ducksss/codex-profiles",
     "title": "codex-profiles",
     "description": "切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口",


### PR DESCRIPTION
## Summary

Add [Agent QA](https://github.com/vostride/agent-qa) to 编程工具 (Programming Tools).

The Chinese entry describes Agent QA as an application tool for authoring, running, and triaging natural-language web and mobile tests, with CLI, dashboard, and MCP interfaces. The same record is added to both the visible README table and `data.json`.

## Validation

- followed the documented JSON schema with a unique UUID and an official repository asset
- kept the README and structured-data descriptions identical and avoided free/open-source claims
- checked for existing listings or proposals, parsed `data.json`, and ran `git diff --check`

## Disclosure

I am affiliated with Agent QA and Vostride. Agent QA's current FSL-1.1-ALv2 release is source-available, not OSI open source; each release converts to Apache-2.0 after two years. Separate model, browser, or device-provider costs may apply.
