### PR TITLE
docs: add SandBase CLI to programming tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@
 | Agent QA | app | 用自然语言编写、运行和排查网页及移动应用测试，提供 CLI、仪表板和 MCP 服务器 | [官网](https://github.com/vostride/agent-qa) |
 | codex-profiles | web | 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口 | [官网](https://github.com/Ducksss/codex-profiles) |
 | Better Agent | app | 本地AI编程代理工作区，统一运行Claude、Codex和Gemini会话，支持并行分叉、任务委派与重启恢复 | [官网](https://github.com/ofekron/better-agent) |
+| SandBase CLI | app | 开源 CLI 与本地 MCP 桥接，让编程 Agent 通过统一接口发现并调用 2,000+ AI 模型 | [官网](https://github.com/sandbaseai/cli) |
 | Orkas | app | 开源本地优先的多智能体桌面工作区，支持并行和串行协作 | [官网](https://orkas.ai/?source=gh_rvelamen) |
 | 豆包AI编程 | web | 豆包推出的AI编程新功能 | [官网](https://www.doubao.com/chat/coding) |
 | Firebase Studio | app | 谷歌推出的编程工具，一站式开发全栈应用 | [官网](https://firebase.studio) |


### PR DESCRIPTION
Adds SandBase CLI to the 编程工具 section.

- Canonical repository: https://github.com/sandbaseai/cli
- Open-source CLI and local MCP bridge
- Discovers and calls 2,000+ AI models through one interface

Disclosure: I contribute to sandbaseai/cli. The entry follows the list's table format and links the official repository.