### PR TITLE
Add PixGT to 商品图生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@
 | 花生图像 | web | AI电商产品图生成和背景抠图工具 | [官网](https://www.hsphoto.cn) |
 | 图生生 | web | 专为电商设计的AI商拍工具 | [官网](https://tushengsheng.com/home) |
 | WeShop唯象 | web | 蘑菇街推出的AI商拍工具 | [官网](https://www.weshop.com) |
+| PixGT | web | 跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴 | [官网](https://www.pixgt.cn) |
 
 ---
 ### 15. 设计工具

--- a/data.json
+++ b/data.json
@@ -6751,6 +6751,17 @@
     "id": "f4ca0520-9a5d-4632-a13f-2cdb8ab7d02b"
   },
   {
+    "url": "https://www.pixgt.cn",
+    "title": "PixGT",
+    "description": "跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴",
+    "image": "https://www.pixgt.cn/images/brand-icon.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "6240da2b-ab81-4343-a017-409c8a84e21f"
+  },
+  {
     "url": "https://www.tripo3d.ai",
     "title": "Tripo AI",
     "description": "AI 3D模型生成平台，支持文本、图像一键生成3D模型",


### PR DESCRIPTION
新增一个条目到「14. 商品图生成」。

- 名称：PixGT
- 链接：https://www.pixgt.cn
- 描述：跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴

按 AGENTS.md 的要求，README.md 和 data.json 已同步更新：新条目用的是新生成的 UUID，category 沿用现有的「商品图生成」，image 指向站点自有的品牌图标。本地跑过 `jq empty data.json`、重复 ID 检查和 `git diff --check`，都通过。

描述里没有写「免费」「开源」这类没有依据的说法。

利益披露：我在 PixGT 团队工作。