### PR TITLE
Add StudyArena to chat assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 | 360智脑 | web | 360搜索最新推出的AI对话聊天机器人 | [官网](https://ai.360.com) |
 | 对话写作猫 | web | 秘塔写作猫推出的AI对话聊天工具 | [官网](https://xiezuocat.com) |
 | 海螺AI | web | MiniMax推出的AI对话助理，已免费开放 | [官网](https://hailuoai.com) |
+| StudyArena | web | 免费比较同一学习问题的三个匿名 AI 回答，投票后揭示模型名称 | [官网](https://studyarena.com) |
 
 ---
 ### 2. 图像工具

--- a/data.json
+++ b/data.json
@@ -673,6 +673,17 @@
     "type": "web"
   },
   {
+    "url": "https://studyarena.com",
+    "title": "StudyArena",
+    "description": "免费比较同一学习问题的三个匿名 AI 回答，投票后揭示模型名称",
+    "image": "https://studyarena.com/icon.png",
+    "category": [
+      "聊天助手"
+    ],
+    "type": "web",
+    "id": "53238464-5572-45a3-ab13-6b340dca8964"
+  },
+  {
     "url": "https://b.quark.cn/apps/qkhomepage_twofoufeb/routes/model",
     "title": "夸克AI",
     "type": "app",


### PR DESCRIPTION
## Summary

Add StudyArena to 聊天助手 in README.md and data.json. StudyArena gives students three anonymous answers to the same study question, lets them vote, then reveals the models. The complete three-answer comparison is free.

## Validation

- Kept README.md and data.json synchronized
- Used a unique UUID and the existing 聊天助手 category
- Verified the canonical URL and icon
- Searched repository files and all open and closed issues and pull requests for StudyArena, studyarena.com, and studyarena.ai
- Ran the catalog validation and git diff --check

## Disclosure

I've been building StudyArena and am proposing it because its side-by-side comparison fits the chat-assistant category.
