### PR TITLE
Sync data.json for Luphra and SEELE TV

### DIFF
--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@
 | GoEnhance | web | AI视频风格转换和画质增强工具 | [官网](https://www.goenhance.ai/) |
 | InVideo AI | web | 人工智能视频创作和剪辑工具 | [官网](https://invideo.io/) |
 | Unscreen | web | AI智能视频背景移除工具 | [官网](https://www.unscreen.com/) |
-| SEELE TV | web | Browser-based AI video creation studio | [官网](https://seele.tv/) |
+| SEELE TV | web | 浏览器端AI视频创作工作室 | [官网](https://seele.tv/) |
 | EbSynth | web | AI将真人视频转化为油画风动画 | [官网](https://ebsynth.com/) |
 | Artflow | web | AI创建生成视频动画 | [官网](https://app.artflow.ai/) |
 | Kaiber | web | 图片文字转视频的AI引擎 | [官网](https://www.kaiber.ai/superstudio/) |

--- a/data.json
+++ b/data.json
@@ -6828,6 +6828,17 @@
     "id": "ed6c3928-1b8a-4ab1-91f8-8e3fdd63ceae"
   },
   {
+    "url": "https://www.luphra.com/",
+    "title": "Luphra",
+    "description": "Prompt-to-matter：文本/草图转可编辑3D并制造实体产品",
+    "image": "https://www.luphra.com/icon.svg",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "8f2a1b14-2e8e-4603-a8a9-77b4083c022a"
+  },
+  {
     "url": "https://aibrm.paluai.com/bairimeng",
     "title": "白日梦",
     "description": "AI视频创作平台，最长可生成六分钟的视频",
@@ -7772,6 +7783,17 @@
     ],
     "type": "web",
     "id": "a5e00b04-ec81-4dca-821d-9f7f9ececb1f"
+  },
+  {
+    "url": "https://seele.tv/",
+    "title": "SEELE TV",
+    "description": "浏览器端AI视频创作工作室",
+    "image": "https://seele.tv/favicon.ico",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "de018197-1657-49c8-a93e-287b3b2a8dfe"
   },
   {
     "url": "https://ebsynth.com/",


### PR DESCRIPTION
## Summary

Follow-up fixes for #46 and #43, which updated only README.md:

- Add missing `data.json` entry for Luphra (3D模型生成), icon URL verified (https://www.luphra.com/icon.svg)
- Add missing `data.json` entry for SEELE TV (视频工具), icon URL verified (https://seele.tv/favicon.ico)
- Translate SEELE TV's README description to Chinese to match the list style

## Validation

- `jq empty data.json` passes
- No duplicate IDs (`jq -r '.[].id' data.json | sort | uniq -d` is empty)
- `git diff --check` passes