### PR TITLE
Add Lunalisa to 商品图生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
-# 🚀 Awesome AI Tools [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# 🚀 Awesome AI Tools [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![GitHub Stars](https://img.shields.io/github/stars/Rvelamen/Awesome-AI-Tools?style=social)](https://github.com/Rvelamen/Awesome-AI-Tools)
 
 ![example](./assets/img.png)
 > 一个持续更新的AI工具全景图，涵盖大语言模型（LLM）、Agent框架、开发工具等资源
 
+> ⭐ 如果这份清单对你有帮助，欢迎在 GitHub 右上角点一个 **Star**，让更多人和 Agent 发现它。
+
 ---
 
 ## 📖 目录
-- [🎯 项目目标](-🎯项目目标)
-- [🗂️ 工具分类](-🗂️工具分类)
-- [🧭 快速导航](-🧭快速导航)
-- [👥 贡献指南](-👥贡献指南)
-- [📜 声明](-📜声明)
-- [🤝 License](-🤝License)
+- [🎯 项目目标](#-项目目标)
+- [🗂️ 工具分类](#️-工具分类)
+- [🧭 快速导航](#-快速导航)
+- [👥 贡献指南](#-贡献指南)
+- [📜 声明](#-声明)
+- [🤝 License](#-license)
 
 ---
 
@@ -29,6 +31,7 @@
 | 名称    | 类型 | 描述       | 链接             |
 | ------- | ---- | -------- | ---------------- |
 | 豆包 | web | 字节跳动推出的免费AI智能助手 | [官网](https://www.doubao.com/chat) |
+| [Auferet](https://auferet.com) | AI game master that remembers your world: persistent memory for characters, places, and lore you upload; solo or multiplayer, 5e & Pathfinder 2e | — | — |
 | 讯飞星火 | web | 科大讯飞推出的AI智能助手 | [官网](https://xinghuo.xfyun.cn/desk) |
 | ChatGPT | web | OpenAI旗下AI对话工具 | [官网](https://chat.openai.com) |
 | Claude | web | ChatGPT的最为有力的竞争对手之一 | [官网](https://claude.ai) |
@@ -90,6 +93,7 @@
 | 360智脑 | web | 360搜索最新推出的AI对话聊天机器人 | [官网](https://ai.360.com) |
 | 对话写作猫 | web | 秘塔写作猫推出的AI对话聊天工具 | [官网](https://xiezuocat.com) |
 | 海螺AI | web | MiniMax推出的AI对话助理，已免费开放 | [官网](https://hailuoai.com) |
+| StudyArena | web | 免费比较同一学习问题的三个匿名 AI 回答，投票后揭示模型名称 | [官网](https://studyarena.com) |
 
 ---
 ### 2. 图像工具
@@ -99,12 +103,14 @@
 | 绘蛙 | web | AI电商营销工具，免费生成商品图和种草文案 | [官网](https://ihuiwa.paluai.com) |
 | 稿定AI | web | 一站式设计工具集，免费AI绘图、图片转AI绘画、AI抠图消除 | [官网](https://www.gaoding.com) |
 | 笔魂AI | web | 设计工具，支持AI抠图、消除、无损放大 | [官网](https://ibihun.com) |
+| ImageChanger | web | 浏览器端AI图片编辑器，提供38个背景、人物、物体、修复和创意转换工作流 | [官网](https://aiimagechanger.app/) |
 | 吐司AI | web | AI绘画模型社区和在线生图平台 | [官网](https://tusiart.com) |
 | 美间AI抠图 | web | 美间AI推出的免费智能抠图工具 | [官网](https://www.meijian.com/mj-box/ai-pic-matting-intro) |
 | 即梦 | web | 抖音旗下免费AI图片创作工具 | [官网](https://jimeng.jianying.com/ai-tool/home) |
 | 阿贝智能 | web | 一站式AI绘本创作平台，副业变现必备 | [官网](https://abeiai.com) |
 | Midjourney | web | AI图像和插画生成工具 | [官网](https://www.midjourney.com/home) |
 | 炉米Lumi | web | 字节跳动推出的AIGC图像创作平台 | [官网](https://artistrylab.net) |
+| Seedream AI Studio | web | 字节跳动出品多模型AI图像生成平台，搭载Seedream 5.0/4.5/4.0，AI图像竞技场排名第一，支持10张参考图一键生成视频 | [官网](https://seedream4.video/) |
 | Civitai | web | 免费的AI图像绘画作品和模型分享平台和社区 | [官网](https://civitai.com/) |
 | 堆友AI反应堆 | web | 阿里旗下堆友推出的多风格AI绘画生成器 | [官网](https://d.design) |
 | 通义万相 | web | 阿里最新推出的AI绘画创作模型 | [官网](https://tongyi.aliyun.com/wanxiang) |
@@ -116,7 +122,10 @@
 | 可灵AI | web | 快手推出的AI图像和视频创作平台 | [官网](https://klingai.kuaishou.com) |
 | AI改图神器 | web | AI万能图片在线编辑器 | [官网](https://img.logosc.cn) |
 | Krea AI | web | 实时AI图像、视频生成和编辑平台 | [官网](https://www.krea.ai) |
+| Rao Edits | web | 浏览器端AI图像生成和参考图编辑工具，可用于社交视觉、产品图和创意工作流 | [官网](https://raoedits.top/) |
+| YingTu | web | 浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比 | [官网](https://yingtu.ai/en) |
 | Photoroom | web | 在线AI图片编辑工具 | [官网](https://www.photoroom.com/zh) |
+| HairWow | web | AI发型试戴和护发建议工具，支持预览发型、发色、刘海、层次和胡须造型 | [官网](https://www.gohairwow.com) |
 | Ribbet.ai | web | 免费的多功能AI图片处理工具箱 | [官网](https://ribbet.ai/) |
 | 万相营造 | web | 阿里旗下推出的多模态AI创意生成平台 | [官网](https://agi.taobao.com) |
 | 悟空图像PhotoSir | web | 新一代专业图像处理软件，更智能、更高效、更好用 | [官网](https://www.photosir.com) |
@@ -364,6 +373,8 @@
 | 腾讯文档智能助手 | web | 腾讯推出的AI文档生成和辅助工具 | [官网](https://docs.qq.com) |
 | Cubox | web | 高效的AI阅读学习助手和信息收集管理工具 | [官网](https://cubox.pro) |
 | Quivr | web | 开源的知识库搭建工具，构建你的第二大脑 | [官网](https://www.quivr.app) |
+| Remio | web | 本地优先的AI记忆和知识库，支持文件、网页、录音、邮件、消息、图片和笔记的索引与语义检索 | [官网](https://remio.ai/) |
+| WizGenerator Story Generator | web | 免费AI故事生成工具，可根据主题、类型、语气和篇幅生成故事草稿，无需注册 | [官网](https://wizgenerator.com/tools/story-generator/) |
 | Coda AI | web | 在线协作平台Coda推出的AI写作和文档助手，类似于Notion AI | [官网](https://coda.io/product/ai) |
 | 有道速读 | web | 网易有道推出的AI论文和文档阅读助手 | [官网](https://read.youdao.com) |
 | 腾讯问卷 | web | 腾讯推出的AI生成调查问卷的免费工具 | [官网](https://wj.qq.com/ai/generate.html) |
@@ -543,6 +554,9 @@
 | ------- | ---- | -------- | ---------------- |
 | 飞书多维表格 | web | 表格形态的 AI 工作流搭建工具 | [官网](https://www.feishu.cn/paid/ai-register) |
 | Manus | web | Monica团队推出的全球首款通用型 AI Agent | [官网](https://manus.im) |
+| IdeaHunter | web | 基于公开需求信号发现并验证应用与微型 SaaS 创业想法 | [官网](https://ideahunter.today) |
+| AnswerLens | web | 审计 B2B SaaS 官网公开证据，检查定价、证明、文档、对比、信任、schema 和 llms.txt 缺口 | [官网](https://app.sfdj.net/) |
+| AISO Tools | web | 检测 ChatGPT、Perplexity 等 AI 助手是否会推荐你的产品，并给出影响被引用的差距 | [官网](https://aisotools.com) |
 | TinyWow | web | 免费在线AI工具箱 | [官网](https://tinywow.com/) |
 | ima.copilot | web | 腾讯推出的AI智能工作台产品，基于混元大模型 | [官网](https://ima.qq.com) |
 | 飞书知识问答 | web | 飞书智能办公推出的AI知识库工具 | [官网](https://ask.feishu.cn/topic) |
@@ -590,6 +604,7 @@
 | 花生图像 | web | AI电商产品图生成和背景抠图工具 | [官网](https://www.hsphoto.cn) |
 | 图生生 | web | 专为电商设计的AI商拍工具 | [官网](https://tushengsheng.com/home) |
 | WeShop唯象 | web | 蘑菇街推出的AI商拍工具 | [官网](https://www.weshop.com) |
+| PixGT | web | 跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴 | [官网](https://www.pixgt.cn) |
 
 ---
 ### 15. 设计工具
@@ -678,6 +693,10 @@
 | 文心快码 | plugin | 百度推出的AI编程助手，基于文心大模型 | [官网](https://comate.baidu.com) |
 | CodeWhisperer | web | 亚马逊推出的免费AI编程助手 | [官网](https://aws.amazon.com/codewhisperer/) |
 | GitHub Copilot | web | GitHub推出的编程工具 | [官网](https://github.com/features/copilot) |
+| Agent QA | app | 用自然语言编写、运行和排查网页及移动应用测试，提供 CLI、仪表板和 MCP 服务器 | [官网](https://github.com/vostride/agent-qa) |
+| codex-profiles | web | 切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口 | [官网](https://github.com/Ducksss/codex-profiles) |
+| Better Agent | app | 本地AI编程代理工作区，统一运行Claude、Codex和Gemini会话，支持并行分叉、任务委派与重启恢复 | [官网](https://github.com/ofekron/better-agent) |
+| Orkas | app | 开源本地优先的多智能体桌面工作区，支持并行和串行协作 | [官网](https://orkas.ai/?source=gh_rvelamen) |
 | 豆包AI编程 | web | 豆包推出的AI编程新功能 | [官网](https://www.doubao.com/chat/coding) |
 | Firebase Studio | app | 谷歌推出的编程工具，一站式开发全栈应用 | [官网](https://firebase.studio) |
 | Cursor | app | AI代码编辑器，快速进行编程和软件开发 | [官网](https://www.cursor.com) |
@@ -702,6 +721,7 @@
 | Sketch2Code | web | 微软AI Lab推出的将手绘草图转换成HTML代码工具 | [官网](https://sketch2code.azurewebsites.net/) |
 | CodeFuse | web | 蚂蚁集团推出的AI代码编程助手 | [官网](https://codefuse.alipay.com) |
 | Tabby | web | 免费开源的自托管AI编程助手 | [官网](https://tabby.tabbyml.com) |
+| TeamoRouter | web | Claude Code/Codex LLM API 智能路由网关，一个Key接入所有主流模型，微信支付宝充值 | [官网](https://teamorouter.com?utm_source=github&utm_medium=issue&utm_campaign=round3&utm_content=awesome-ai-tools-cn) |
 | C知道 | web | CSDN推出的AI技术问答工具 | [官网](https://so.csdn.net/chat) |
 | 驭码CodeRider | web | 极狐GitLab推出的AI编程与软件智能研发助手 | [官网](https://coderider.gitlab.cn) |
 | Duo Chat | web | GitLab推出的AI编程助手 | [官网](https://about.gitlab.com/gitlab-duo) |
@@ -709,6 +729,7 @@
 | Augment Code | web | AI编程辅助工具，专为大型代码库设计 | [官网](https://www.augmentcode.com) |
 | Devin | web | 首个全自主的AI软件工程师智能体 | [官网](https://preview.devin.ai) |
 | Plandex | web | 免费开源的基于终端的AI编程引擎 | [官网](https://plandex.ai) |
+| Tree Ring Memory | web | 本地优先的AI智能体记忆生命周期层，提供Rust CLI/TUI、SQLite/FTS召回、审计、遗忘和整合 | [官网](https://terminallylazy.github.io/Tree-Ring-Memory/) |
 | Fitten Code | web | 非十科技推出的免费AI代码助手 | [官网](https://code.fittentech.com) |
 | BLACKBOX AI | web | 黑箱AI编程助理，快速代码生成 | [官网](https://www.useblackbox.io) |
 | Solo | web | Mozilla推出的零编程无代码AI网站建设工具 | [官网](https://soloist.ai) |
@@ -716,6 +737,7 @@
 | CodeArts Snap | web | 华为云推出的智能编程助手 | [官网](https://www.huaweicloud.com/product/codeartside/snap.html) |
 | AskCodi | web | 你的个人AI编程助手 | [官网](https://www.askcodi.com/) |
 | v0.dev | web | AI生成前端React/UI组件，由Vercel推出 | [官网](https://v0.dev) |
+| Roblox GUI Maker | web | 输入提示词生成Roblox Studio GUI布局和Lua入门代码 | [官网](https://robloxguimaker.dev/) |
 | Boxy | web | CodeSandbox推出的AI编程助手 | [官网](https://codesandbox.io/blog/meet-boxy-ai-coding-assistant) |
 | Quest AI | web | AI将设计稿生成React代码，支持JavaScript和TypeScript | [官网](https://www.quest.ai) |
 | 天工智码Skycode | web | AI智能编程助手，轻松生成各种代码 | [官网](https://sky-code.singularity-ai.com/index.html#/) |
@@ -792,6 +814,7 @@
 | Cutout.Pro | web | AI在线处理图片 | [官网](https://www.cutout.pro/) |
 | 白日梦 | web | AI视频创作平台，最长可生成六分钟的视频 | [官网](https://aibrm.paluai.com/bairimeng) |
 | 绘蛙AI视频 | web | 绘蛙推出的AI图生视频工具 | [官网](https://www.ihuiwa.com/workspace/ai-video/custom-action) |
+| ImagineClip | web | AI 视频生成工具，可从提示词、图片和效果生成头像短片、风格化场景和社交视频 | [官网](https://imagineclip.com) |
 | 讯飞绘镜 | web | 科大讯飞推出的AI短视频创作平台 | [官网](https://typemovie.art) |
 | Vidu | web | 生数科技推出的AI视频生成大模型 | [官网](https://www.vidu.cn) |
 | SoundView | web | AI视频本地化工具，支持视频配音和翻译 | [官网](https://soundviewai.com) |
@@ -806,6 +829,7 @@
 | Runway | web | AI视频工具，绿幕抠除、视频生成、动态捕捉等功能 | [官网](https://runwayml.com) |
 | PVID | web | 免费AI视频生成器，聚合Kling 3.0、Sora 2、Veo 3.1 | [官网](https://pvid.app/) |
 | Pika | web | Pika Labs推出的AI视频生成和编辑工具 | [官网](https://pika.art/) |
+| ImagineClip | web | AI视频生成工具，支持社交短片、头像视频和风格化场景创作 | [官网](https://imagineclip.com?ref=awesome-ai-tools) |
 | Dream Machine | web | Luma AI推出的AI视频生成工具 | [官网](https://lumalabs.ai/dream-machine) |
 | 通义万相AI视频 | web | 通义万相AI视频是阿里推出的... | [官网](https://tongyi.aliyun.com/wanxiang/wanxvideo) |
 | Sora | web | OpenAI推出的AI视频生成模型 | [官网](https://openai.com/sora) |
@@ -868,6 +892,7 @@
 | 闪剪 | web | AI数字人短视频创作工具 | [官网](https://shanjian.tv/) |
 | Wonder Studio | web | AI自动为CG角色制作动画、打光并将其合成到真人场景中 | [官网](https://wonderdynamics.com/) |
 | Magicam | web | 实时的AI直播/视频换脸工具 | [官网](https://magicam.ai/) |
+| LiveFaceSwap AI换脸 | web | 提供网页体验和Windows客户端的实时AI换脸工具，支持变装、风格重绘与虚拟摄像头输出 | [官网](https://livefaceswap.ai/zh) |
 | LTX Studio | web | AI电影制作和视频短片生成平台 | [官网](https://ltx.studio/) |
 | Clipfly | web | 一站式AI长视频制作和编辑平台 | [官网](https://www.clipfly.ai/) |
 | Captions | web | AI驱动的视频剪辑和制作平台 | [官网](https://www.captions.ai/) |
@@ -875,6 +900,7 @@
 | GoEnhance | web | AI视频风格转换和画质增强工具 | [官网](https://www.goenhance.ai/) |
 | InVideo AI | web | 人工智能视频创作和剪辑工具 | [官网](https://invideo.io/) |
 | Unscreen | web | AI智能视频背景移除工具 | [官网](https://www.unscreen.com/) |
+| SEELE TV | web | 浏览器端AI视频创作工作室 | [官网](https://seele.tv/) |
 | EbSynth | web | AI将真人视频转化为油画风动画 | [官网](https://ebsynth.com/) |
 | Artflow | web | AI创建生成视频动画 | [官网](https://app.artflow.ai/) |
 | Kaiber | web | 图片文字转视频的AI引擎 | [官网](https://www.kaiber.ai/superstudio/) |
@@ -890,6 +916,7 @@
 | DeepBrain | web | AI口播视频生成工具 | [官网](https://www.aistudios.com/) |
 | Synthesia | web | AI视频生成平台 | [官网](https://www.synthesia.io/) |
 | Lumen5 | web | AI将博客文章转换成视频 | [官网](https://lumen5.com/) |
+| videos.social | web | 博客/PDF/提示词转为可编辑无脸视频 | [官网](https://videos.social/?utm_source=rvelamen-awesome-ai-tools&utm_medium=directory&utm_campaign=listing-wave-d) |
 | Rephrase.ai | web | AI文字到视频生成 | [官网](https://ahrefs.com/writing-tools/paraphrasing-tool) |
 | 万彩微影 | web | AI智能自动生成动画短视频 | [官网](https://www.animiz.cn/microvideo/) |
 | 录咖 | web | 一站式AI音视频总结和转录处理工具 | [官网](https://reccloud.cn/) |
@@ -929,6 +956,7 @@
 | Cutout.Pro老照片上色 | web | Cutout.Pro推出的黑白图片上色 | [官网](https://www.cutout.pro/zh-CN/photo-colorizer-black-and-white) |
 | Palette | web | AI图片调色上色 | [官网](https://palette.fm/) |
 | Playground AI | web | AI图片生成和修图 | [官网](https://playgroundai.com/) |
+| ArtImageHub | web | AI老照片修复——去划痕、降噪、黑白上色，在线处理，免费预览，$4.99下载 | [官网](https://artimagehub.com) |
 
 ---
 ### 21. 图片无损放大
@@ -1006,6 +1034,7 @@
 | Bg Eraser | web | 图片物体抹除和清理 | [官网](https://bgeraser.com/) |
 | SnapEdit | web | AI移除图片中的任何物体 | [官网](https://snapedit.app/) |
 | Cleanup.pictures | web | 智能移除图片中的物体、文本、污迹、人物或任何不想要的东西 | [官网](https://cleanup.pictures/) |
+| ClearCrowds | web | AI照片清理和图片编辑工具，可移除人群、物体、文字、眼镜眩光等画面干扰，并支持预设与提示词编辑 | [官网](https://www.clearcrowds.com) |
 | Cutout.Pro Retouch | web | Cutout.Pro推出的AI图片物体涂抹去除工具 | [官网](https://www.cutout.pro/zh-CN/image-retouch-remove-unwanted-objects) |
 | 蜜蜂剪辑 | web | AI去水印工具，支持图片和30+流行短视频平台 | [官网](https://beecut.cn/online-watermark-remover) |
 | HitPaw Watermark Remover | web | AI图片和视频去水印工具 | [官网](https://www.hitpaw.com/remove-watermark.html) |
@@ -1021,6 +1050,7 @@
 | Hitems | web | 数美万物推出的AI创意物品生成社区 | [官网](https://hitems.ai) |
 | VoxCraft | web | AI生成3D模型的工具 | [官网](https://voxcraft.ai) |
 | Meshy | web | AI快速从文本或图像生成3D模型 | [官网](https://www.meshy.ai) |
+| Luphra | web | Prompt-to-matter：文本/草图转可编辑3D并制造实体产品 | [官网](https://www.luphra.com/) |
 
 ---
 
@@ -1060,7 +1090,7 @@ git clone https://github.com/Rvelamen/Awesome-AI-Tools.git
 
 ## 📜 声明
 
-以下站点列表来源于网络收集，若有侵权请提 [Issues](https://github.com/lzwme/chatgpt-nav/issues) 处理。
+以下站点列表来源于网络收集，若有侵权请提 [Issues](https://github.com/Rvelamen/Awesome-AI-Tools/issues) 处理。
 
 
 
@@ -1068,4 +1098,4 @@ git clone https://github.com/Rvelamen/Awesome-AI-Tools.git
 
 ## 🤝 License
 
-MIT License | © 2025
+MIT License | © 2025–2026

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@
 | 图生生 | web | 专为电商设计的AI商拍工具 | [官网](https://tushengsheng.com/home) |
 | WeShop唯象 | web | 蘑菇街推出的AI商拍工具 | [官网](https://www.weshop.com) |
 | PixGT | web | 跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴 | [官网](https://www.pixgt.cn) |
+| Lunalisa | web | AI创意工作台，13种图像模型+22种视频模型生成商品图、营销海报和白底listing图 | [官网](https://luna-lisa.art) |
 
 ---
 ### 15. 设计工具

--- a/data.json
+++ b/data.json
@@ -9324,5 +9324,16 @@
     "id": "071a3525-cc75-4508-a307-7368d8727dcf",
     "title": "WizGenerator Story Generator",
     "type": "web"
+  },
+  {
+    "url": "https://luna-lisa.art",
+    "description": "AI creative workspace for product photos, marketing posters, and white-background listing images across 13 image models and 22 video models",
+    "image": "https://luna-lisa.art/lunalisa-mark.png",
+    "category": [
+      "商品图生成"
+    ],
+    "id": "0af217ce-1db6-4a31-918c-209acb82a03c",
+    "title": "Lunalisa",
+    "type": "web"
   }
 ]

--- a/data.json
+++ b/data.json
@@ -1,9108 +1,9328 @@
 [
-    {
-        "url": "https://www.doubao.com/chat",
-        "description": "字节跳动推出的免费AI智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a371b2b7-d354-45c7-9caf-46bb38991fd4.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "2c4b2fed-dc11-4296-8c3a-c957dbd95c5a",
-        "title": "豆包",
-        "type": "web"
-    },
-    {
-        "url": "https://xinghuo.xfyun.cn/desk",
-        "description": "科大讯飞推出的AI智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/34b8c8d1-7514-477a-9e00-05926a9c081d.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "80e8d1b9-420c-4ad8-a6ab-32adfe82a15b",
-        "title": "讯飞星火",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.openai.com",
-        "description": "OpenAI旗下AI对话工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3d2c0c8a-65a4-4ae8-b71b-064fb0dbdec7.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "bb9594ab-be67-481b-a4a4-f6df2de4274d",
-        "title": "ChatGPT",
-        "type": "web"
-    },
-    {
-        "url": "https://claude.ai",
-        "description": "ChatGPT的最为有力的竞争对手之一",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/745166c5-4bdb-417f-abc5-f414961e630b.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "5ab96b73-3ed3-4fe8-9336-03ba10b75c5f",
-        "title": "Claude",
-        "type": "web"
-    },
-    {
-        "url": "https://gemini.google.com",
-        "description": "Google推出的AI聊天对话机器人Gemini",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/760aa351-febb-40bb-9965-8ff35c6f45ef.webp",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "c61400db-f4ef-4fd0-92c9-25280e22459e",
-        "title": "Gemini",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.deepseek.com/",
-        "description": "幻方量化旗下深度求索推出的开源大模型和聊天助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/598bc1aa-f428-4416-b762-7e176c8b07e8.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "0d066a34-78fa-4d11-b71b-83595b2b2e23",
-        "title": "DeepSeek",
-        "type": "web"
-    },
-    {
-        "url": "https://kimi.moonshot.cn/",
-        "description": "一次搜索可精读500个页面，会推理解析，能深度思考的AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/846650d3-c65c-419c-b475-620a92aee910.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "460497ba-cd82-4edf-963d-60e4040a5497",
-        "title": "Kimi智能助手",
-        "type": "web"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/qianwen",
-        "description": "阿里推出的自研大模型，通情、达义，你的全能AI助手！",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9332782-5542-4a6a-9492-89804dab08a3.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "9e021e8a-3d34-42be-8bee-8a13e9449e8b",
-        "title": "通义千问",
-        "type": "web"
-    },
-    {
-        "url": "https://chatglm.cn",
-        "description": "免费全能的AI助手，支持AI绘画、视频生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a1ba6f5-7237-4063-9279-875497f567ef.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "4870b3c2-c7d6-4640-bde3-6408c6f7b20b",
-        "title": "智谱清言",
-        "type": "web"
-    },
-    {
-        "url": "https://wenxiaobai.paluai.com",
-        "description": "元石科技推出的AI智能助手，支持DeepSeek满血版",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9dc640f6-a8e8-4438-8512-037f919d0b55.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "604fb838-bdce-4012-b7b4-f01716837980",
-        "title": "问小白",
-        "type": "web"
-    },
-    {
-        "url": "https://yuanbao.tencent.com",
-        "description": "腾讯推出的免费AI智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7434aee2-ff85-4286-8016-355c63027d1e.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "ec719dcf-2db5-436d-ac95-69b92609f04e",
-        "title": "腾讯元宝",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.qwen.ai/",
-        "description": "阿里通义推出的 Qwen AI 大模型Web UI界面",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1b5018f4-451a-4cb4-adf4-43516c6796c4.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "a89de616-bf14-4ead-aab6-21236b19e9f0",
-        "title": "Qwen Chat",
-        "type": "web"
-    },
-    {
-        "url": "https://x.ai/grok",
-        "description": "马斯克旗下xAI推出的人工智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/18932599-e115-4369-a154-fbbb5e06db56.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "6164d30d-d38c-430e-a1d5-5160cd04cafd",
-        "title": "Grok",
-        "type": "web"
-    },
-    {
-        "url": "https://poe.com",
-        "description": "问答社区Quora推出的问答机器人工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ca0d486f-d09f-490b-a07a-7b377e265d0a.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "0fd440eb-e6f0-4554-864f-d71c1d0ea288",
-        "title": "Poe",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.minimaxi.com",
-        "description": "MiniMax推出的免费AI智能聊天助理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1dc09d69-05dd-4d0b-b009-0562b2eb797c.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "4124ecd0-3563-4aee-a621-b33a6867bf50",
-        "title": "MiniMax",
-        "type": "web"
-    },
-    {
-        "url": "https://xiaoyi.huawei.com/chat",
-        "description": "华为旗下小艺AI助手网页端，已接入DeepSeek-R1",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4d36ca7-6f12-41df-b151-69562d498c79.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "ae24707a-a1f0-4903-aeed-140a01ff05d1",
-        "title": "华为小艺",
-        "type": "web"
-    },
-    {
-        "url": "https://yiyan.baidu.com",
-        "description": "百度推出的基于文心大模型的AI对话互动工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80223edf-dce6-4fda-aa7b-200593085613.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "7e49bbd9-3ca4-461c-9d85-bbd8c752b4f0",
-        "title": "文心一言",
-        "type": "web"
-    },
-    {
-        "url": "https://yuewen.cn/chats/new",
-        "description": "阶跃星辰推出的支持多模态的AI聊天机器人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a8ffdc0a-ac92-4434-b54f-64f53fc07df5.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "4d1d9ecb-49fc-45a9-b43b-9f7cd0b1d46a",
-        "title": "阶跃AI",
-        "type": "web"
-    },
-    {
-        "url": "https://ying.baichuan-ai.com/chat",
-        "description": "百川智能推出的免费AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d3030893-2b4d-4b3c-9bfa-d2586a1053af.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "d3cbd8f7-6e22-443a-87cd-b8c3c53712f0",
-        "title": "百小应",
-        "type": "web"
-    },
-    {
-        "url": "https://www.tiangong.cn",
-        "description": "昆仑万维推出的AI智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7df147f4-f027-48e6-8a6b-7e6dcd150a27.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "214ea34b-2463-4fb7-8b9d-5367462745e3",
-        "title": "天工AI",
-        "type": "web"
-    },
-    {
-        "url": "https://copilot.microsoft.com/",
-        "description": "微软推出的网页版Copilot助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/751ba916-b264-41ba-b2b0-356994c1181d.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "7f658af1-4626-4fb1-a839-a7843b95c2d1",
-        "title": "Copilot",
-        "type": "web"
-    },
-    {
-        "url": "https://character.ai",
-        "description": "创建虚拟角色并与其对话",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c433de76-0f95-4ba9-8c5e-28226f76217d.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "22497784-8a3e-4900-be21-ab0c22945c9a",
-        "title": "Character.AI",
-        "type": "web"
-    },
-    {
-        "url": "https://matter.ai/",
-        "description": "罗永浩旗下 Jarvis 项目推出的 AI 智能助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/240bd64e-5170-46a1-bcc8-8148164bce97.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "aef173bb-6c01-4e48-bcd0-4a969ce5fe8b",
-        "title": "J1 Assistant",
-        "type": "web"
-    },
-    {
-        "url": "https://www.meta.ai",
-        "description": "Meta推出的免费AI聊天助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ccea1c6e-8824-4d98-b9f5-bc9e7eace7dc.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "7fa7e017-1f63-4b34-a559-ea9d923d5a55",
-        "title": "Meta AI助手",
-        "type": "web"
-    },
-    {
-        "url": "https://www.seeles.ai",
-        "description": "Seele公司推出的「AI+3D」情感陪伴产品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21b171ec-5f4d-49c5-a532-7e51bd11ca49.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "6a9e0536-5505-47ad-a760-398bd4009b2d",
-        "title": "Koko AI",
-        "type": "web"
-    },
-    {
-        "url": "https://beta.ohai.bot/discover",
-        "description": "月之暗面旗下推出的AI角色扮演虚拟陪伴应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/272aa863-0d38-4eea-b71e-7d748f3c87ad.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "2c2f4e6e-ba01-4d8f-a561-bc11868499c0",
-        "title": "Ohai",
-        "type": "web"
-    },
-    {
-        "url": "https://www.me.bot",
-        "description": "心识宇宙推出的个性化AI伴侣产品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c1e71275-853d-429e-9314-662c3fccef18.webp",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "40cde9be-aaab-4fe8-bd44-b2972b20982e",
-        "title": "Me.bot",
-        "type": "web"
-    },
-    {
-        "url": "https://www.sayloai.com",
-        "description": "AI驱动的故事角色扮演游戏应用，沉浸式的剧本互动体验",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef573be4-e8b5-458d-b5ee-d74fd292c15b.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "b860fa86-eb33-4698-a2b1-5136c6327584",
-        "title": "Saylo",
-        "type": "web"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/xingchen",
-        "description": "用AI定制属于你自己的IP角色",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfd40d27-0624-406b-8161-23f858fa0eff.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "1986a8f7-25cb-4f16-8f32-a1e8c95e8067",
-        "title": "通义星尘",
-        "type": "web"
-    },
-    {
-        "url": "https://cueme.cn",
-        "description": "夸克推出的AI智能对话助手，支持2万字长文写作",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/98e9daa7-59b2-4fd8-bee3-c123e7959f18.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "9abf440e-3734-43a6-ae86-b116f64ea9df",
-        "title": "CueMe",
-        "type": "web"
-    },
-    {
-        "url": "https://ciyuan.ideaflow.pro",
-        "description": "AI互动内容平台，虚拟角色逗你开心",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d9f2cd95-dc12-41ce-a782-56b24030a8a2.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "0d6fcc26-3eef-468d-a961-caaa1377a99b",
-        "title": "造梦次元",
-        "type": "web"
-    },
-    {
-        "url": "https://www.museland.ai",
-        "description": "沉浸式AI角色扮演产品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7469caf6-e2fe-4a78-91f4-95137adcc09c.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "ef6cddb8-bda1-4df0-94cf-901aeae59fb3",
-        "title": "Museland",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.baidu.com",
-        "description": "百度推出的多场景AI智能体助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f5f22366-0a06-49e7-b44d-eb5701e4b632.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "c9de15a0-fa1d-40a8-9aa1-5337fc701b67",
-        "title": "百度AI助手",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.sensetime.com",
-        "description": "商汤科技推出的类ChatGPT的人工智能大语言模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2c86b1d3-9f0c-4813-a22e-50d6a796929a.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "88ab4f56-8ebe-49eb-bb7a-a8f69897f097",
-        "title": "商量SenseChat",
-        "type": "web"
-    },
-    {
-        "url": "https://wukong.com/tool",
-        "description": "字节跳动推出的免费AI对话助手和个人助理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2523ebe-0dba-4e97-b52a-4d45952025bc.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "a4a8fa70-73a2-4243-9c01-e06d17d14c98",
-        "title": "小悟空",
-        "type": "web"
-    },
-    {
-        "url": "https://taichu-web.ia.ac.cn/#/welcome",
-        "description": "中科院与武智院推出的千亿参数全模态大模型和助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27429ee0-5860-4708-882b-629eb7bcf299.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "cbc713c1-16bb-4f0c-ad20-6cd323fa0ea6",
-        "title": "紫东太初",
-        "type": "web"
-    },
-    {
-        "url": "https://chatwiz.cn/h5/feely",
-        "description": "字节跳动旗下推出的AI虚拟交友聊天平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3cecf927-6c55-4dfc-b99d-db1837c8a6d2.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "d947bdc1-b80f-4ea5-94e0-a5b4cb528430",
-        "title": "小黄蕉",
-        "type": "web"
-    },
-    {
-        "url": "https://maopaoya.com",
-        "description": "阶跃星辰推出的AI聊天机器人和智能体平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da09a219-779c-426c-889c-591b265a68f5.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "0870ec15-09fd-476a-937d-45d5c4ed115f",
-        "title": "冒泡鸭",
-        "type": "web"
-    },
-    {
-        "url": "https://www.cici.com/browser-extension/landing/zh",
-        "description": "豆包国际版，字节跳动面向海外市场推出的AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8943e53-0a8b-4333-8817-6cbe4c18e5a0.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "b6020b8b-7b4e-4b60-a311-c9cb77c00667",
-        "title": "Cici",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.baichuan-ai.com",
-        "description": "百川智能推出的大模型助手，融合了意图理解、信息检索以及强化学习技术",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4e3f8d02-1736-4259-8825-5174b097d83f.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "4aecff56-5fd5-4c42-8489-c454eb703a85",
-        "title": "百川大模型",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.mistral.ai",
-        "description": "Mistral推出的AI对话聊天助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9fe949d3-f581-4f49-b7ee-68d984172387.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "a2536e3f-d452-46e0-b799-87db423a0228",
-        "title": "Le Chat",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.baidu.com/",
-        "description": "百度最新上线的AI搜索对话工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2fa3607d-00b4-4ac3-a1f6-c448ea43a7df.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "13c369ef-d4f4-4e5b-87d1-6bdeda3acf0e",
-        "title": "百度AI伙伴",
-        "type": "web"
-    },
-    {
-        "url": "https://cloud.baidu.com/product/infoflow.html",
-        "description": "百度智能云发布的基于文心一言的AI原生应用和Copilot“超级助理”",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ff54777-f365-4c6c-91af-3aad14e5a8a5.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "a023f697-3a8b-4cda-a15a-e713356fc7b6",
-        "title": "超级助理",
-        "type": "web"
-    },
-    {
-        "url": "https://workspace.dingtalk.com",
-        "description": "钉钉推出的个人版办公应用程序，内置AI智能助手，可进行AI创作、AI对话、AI绘画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9b0e25e5-ee64-48f9-bd82-4c378d9872ae.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "5e0fa227-a23f-45fe-b552-1b721a04a5e8",
-        "title": "钉钉·个人版",
-        "type": "web"
-    },
-    {
-        "url": "https://wanderboat.ai",
-        "description": "硅谷初创公司UTA AI推出的AI旅行助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27df4d9e-2bb0-4754-af7c-a82dee894672.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "98f16948-acee-4fa4-accd-66d444037638",
-        "title": "Wanderboat",
-        "type": "web"
-    },
-    {
-        "url": "https://www.langboat.com/portal/mengzi-gpt",
-        "description": "基于孟子GPT大模型的AI对话机器人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4fe2d25e-2676-4c8f-b580-ae87112b58d5.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "cfce49c2-04b1-4144-9d7f-7667700c1695",
-        "title": "MChat",
-        "type": "web"
-    },
-    {
-        "url": "https://luca-beta.modelbest.cn/",
-        "description": "面壁智能推出的千亿多模态大模型免费智能对话助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cdd79f9a-e2df-40d5-b95b-c085dd19115a.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "03be11be-b0cd-4a3c-800b-2941aa26d5dd",
-        "title": "Luca面壁露卡",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.xverse.cn/xchat/index.html",
-        "description": "元象XVERSE大模型驱动的AI聊天助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a8f27f8-6b5a-4d09-a826-8e772360edca.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "d474c8c4-0d7b-407b-a42c-02c66efbbb2d",
-        "title": "元象XChat",
-        "type": "web"
-    },
-    {
-        "url": "https://www.chitchop.com",
-        "description": "字节旗下面向海外用户推出的免费大模型产品和AI助手工具箱",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e206fa0b-d621-41f7-90fd-16fbfb0e92cf.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "fe47fb10-74b9-4e7f-849e-eb0e2d808bb9",
-        "title": "ChitChop",
-        "type": "web"
-    },
-    {
-        "url": "https://www.modelscope.cn/studios/iic/ModelScopeGPT",
-        "description": "阿里达摩院推出的大小模型协同的智能助手，具备作诗、绘画、视频生成、语音播放等多模态能力",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/316ae173-70e1-4f49-a9c1-7e0bac24e02e.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "8dfbbf9a-cf3f-4b9e-b604-39fb80450e63",
-        "title": "魔搭GPT（ModelScopeGPT）",
-        "type": "web"
-    },
-    {
-        "url": "https://huggingface.co/chat/",
-        "description": "HuggingFace推出的在线聊天机器人，基于Open Assistant模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f310f59f-5c04-4ec8-91f5-a362470942a3.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "edd87ce6-8bc8-4c94-8f30-787ab997ec1a",
-        "title": "HuggingChat",
-        "type": "web"
-    },
-    {
-        "url": "https://tigerbot.com",
-        "description": "虎博科技推出的AI对话聊天机器人，基于TigerBot开源大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1fbae9a7-78be-439f-be9a-5ed917245897.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "f024643b-8280-4d9e-bb62-42b19f331eac",
-        "title": "TigerBot",
-        "type": "web"
-    },
-    {
-        "url": "https://research.stability.ai/chat",
-        "description": "Stability AI 最新推出的免费聊天对话网站",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4545bd70-0ac1-48fc-af61-5d6956678ab6.png",
-        "category": [
-            "聊天助手",
-            "图像工具",
-            "图片插画生成"
-        ],
-        "id": "0c39c6f5-bc44-4902-9a80-b3e65f6f0470",
-        "title": "Stable Chat",
-        "type": "web"
-    },
-    {
-        "url": "https://chat.colossalai.org",
-        "description": "Colossal-AI推出的免费开源版ChatGPT聊天机器人替代品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1047a32-2b8c-4df3-ab83-916eab97e3aa.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "f0d09b5a-db64-4ec3-9d2e-b86f60b463b9",
-        "title": "ColossalChat",
-        "type": "web"
-    },
-    {
-        "url": "https://www.jasper.ai/chat",
-        "description": "Jasper针对内容创作者出品的AI聊天工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51f74926-1609-4245-abbe-8aa2891b24d2.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "0aa4eed9-533e-42f8-bf60-379661b003ab",
-        "title": "Jasper Chat",
-        "type": "web"
-    },
-    {
-        "url": "https://chat-sonic.ai/#",
-        "description": "WriteSonic出品的ChatGPT竞品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b5deaa6c-f4de-4db7-a62d-25f224abc624.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "9d81186b-68bf-46a8-b172-c2340e46f97e",
-        "title": "ChatSonic",
-        "type": "web"
-    },
-    {
-        "url": "https://replika.ai/",
-        "description": "AI对话陪伴工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4a4073a-248d-4f4d-a0c0-c28f7b9b459d.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "f196398d-0866-4ff9-ac28-06c440d7f7a1",
-        "title": "Replika",
-        "type": "web"
-    },
-    {
-        "url": "https://pi.ai/talk",
-        "description": "DeepMind联创新公司推出的AI聊天机器人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96fd39c8-fdf3-4dbe-8bf5-c89dba680200.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "f12875a5-cb95-406e-a3ee-a3b5e7f6f774",
-        "title": "Pi",
-        "type": "web"
-    },
-    {
-        "url": "https://ai.360.com",
-        "description": "360搜索最新推出的AI对话聊天机器人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cac87af3-9caa-4133-b29a-c4644840ad27.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "2fd0b362-e5ac-4645-9550-d75ea0a0966a",
-        "title": "360智脑",
-        "type": "web"
-    },
-    {
-        "url": "https://xiezuocat.com",
-        "description": "秘塔写作猫推出的AI对话聊天工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f281fe07-ea60-4ded-82a8-8a630c7b3576.png",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "48c322e9-6aa3-40dd-b016-d6dbea1edca0",
-        "title": "对话写作猫",
-        "type": "web"
-    },
-    {
-        "url": "https://hailuoai.com",
-        "title": "海螺AI",
-        "description": "MiniMax推出的AI对话助理，已免费开放",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/342d526d-710b-4a24-ae96-7892f755b304.png?v=3",
-        "category": [
-            "聊天助手"
-        ],
-        "id": "e329c605-b024-4f87-b855-cc856c68b594",
-        "type": "web"
-    },
-    {
-        "url": "https://b.quark.cn/apps/qkhomepage_twofoufeb/routes/model",
-        "title": "夸克AI",
-        "type": "app",
-        "description": "集AI搜索、网盘、文档、创作等功能于一体的应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a49c1167-8598-4071-b10d-47f2f5447b0f.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "3024a58b-7f54-4052-b93b-6427c4ce9ff3"
-    },
-    {
-        "url": "https://iflow.cn",
-        "title": "心流",
-        "type": "web",
-        "description": "阿里旗下推出的AI搜索助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a9968cc4-0843-46c8-bf0b-84548e97fa2a.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "d47eff1f-a605-44f5-8e55-d8374edccb96"
-    },
-    {
-        "url": "https://metaso.cn",
-        "title": "秘塔AI搜索",
-        "type": "web",
-        "description": "最好用的AI搜索工具，没有广告，直达结果",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d97d01e8-43d4-411c-b958-0b363150e626.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "5fc79bbc-c259-4254-a076-70d64729c74c"
-    },
-    {
-        "url": "https://www.perplexity.ai",
-        "title": "Perplexity",
-        "type": "web",
-        "description": "强大的对话式搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a95b7bf-df6f-4559-bc1d-f21bbd0e8622.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "6ae476ee-845e-4afc-af25-c0978b51d8e6"
-    },
-    {
-        "url": "https://chatgpt.com/",
-        "title": "SearchGPT",
-        "type": "web",
-        "description": "OpenAI最新推出的搜索引擎，内测开放",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e110cfe-db43-4a33-9231-0ac62be98266.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "870a2eca-bbf6-456e-b4ce-38cc3ce5c185"
-    },
-    {
-        "url": "https://flowith.net/blank",
-        "title": "Flowith",
-        "type": "web",
-        "description": "节点交互式AI搜索和对话工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8d3fb27-2992-41d4-a135-14dc9d47fcc9.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "5889c9d3-461c-4ef8-b2ee-4c610388d76a"
-    },
-    {
-        "url": "https://www.genspark.ai",
-        "title": "Genspark",
-        "type": "web",
-        "description": "基于智能体的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c8310a4-d38a-4263-877c-90e34e7bbe51.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "46fd5ee6-8647-43dc-925b-93ce867be0ce"
-    },
-    {
-        "url": "https://devv.ai/zh",
-        "title": "Devv",
-        "type": "web",
-        "description": "面向程序员的新一代搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8c50dc5-ef61-4fa9-8e36-217cd2b12add.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "0015bf87-b9b5-49bd-9ac8-0532d49368b2"
-    },
-    {
-        "url": "https://zhida.zhihu.com",
-        "title": "知乎直答",
-        "type": "web",
-        "description": "知乎推出的搜索引擎，直达问题答案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e57659d1-a653-42f4-b5b2-552fc30d1693.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "7d3072aa-89c0-46bb-b048-5b1102ded9b7"
-    },
-    {
-        "url": "https://www.n.cn",
-        "title": "纳米搜索",
-        "type": "web",
-        "description": "360公司推出的AI搜索应用，一切皆可生成视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cffff956-f50e-4a10-9f1a-ff6e7f27ea11.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "4f7cc133-9eb2-4894-aabf-4b4d5ae250f2"
-    },
-    {
-        "url": "https://chat.baidu.com/search",
-        "title": "百度AI探索版",
-        "type": "web",
-        "description": "百度推出的深度搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80e73ff4-61d9-4663-8b50-cdc0ab496714.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "5380338a-3c72-434c-b87b-c5b8087ab4d7"
-    },
-    {
-        "url": "https://felo.ai/search",
-        "title": "Felo",
-        "type": "web",
-        "description": "免费AI智能搜索引擎，支持社交联网搜索和多语种问答结果",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e235ec8b-84a7-4836-a887-e639bf9d2d16.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "dabbf87f-1e56-4889-8567-0f4a6d1d15a1"
-    },
-    {
-        "url": "https://www.aminer.cn/",
-        "title": "AMiner",
-        "type": "web",
-        "description": "智谱AI推出的大模型学术平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/888d330f-bd43-46f8-b34b-32761d2830c9.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "ddbccb3b-0dac-4cb9-8f38-eb50400b8ecb"
-    },
-    {
-        "url": "https://tiangong.cn",
-        "title": "天工AI搜索",
-        "type": "web",
-        "description": "昆仑万维最新推出的结合大模型的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/67adbea4-596a-497c-9d44-41ba69b8cb0b.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "b11d5f76-fa1c-4b98-9af0-89584dee3bff"
-    },
-    {
-        "url": "https://new-front.chatglm.cn/webagent/landing/index.html",
-        "title": "清言插件",
-        "type": "plugin",
-        "description": "智谱推出的浏览器AI插件，支持AutoGLM、站内高级检索",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f5541983-de84-468e-a162-448a057de00d.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "266ff5b5-d052-42bb-bead-2656cbb6eac4"
-    },
-    {
-        "url": "https://dashboard.exa.ai/playground",
-        "title": "Exa AI",
-        "type": "web",
-        "description": "专门为AI模型设计的搜索引擎平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/00ec479a-c92d-4b3d-af74-25fc33c70030.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "d73aa1ab-cab3-4cef-b203-0292e7a6a2ef"
-    },
-    {
-        "url": "https://www.reddo.cloud/search_home",
-        "title": "Reddo",
-        "type": "web",
-        "description": "全球产品信息搜索引擎，能语义化搜索任何公开的产品与公司",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8aebbca5-44bb-4254-b046-ad42ce9166b9.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "93e20943-6bd3-493e-a283-717d7e16a1cb"
-    },
-    {
-        "url": "https://bochaai.com/",
-        "title": "博查AI搜索",
-        "type": "web",
-        "description": "支持多模型的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ba1395c-7ad2-4a3d-a412-f53cf713a159.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "65c373bf-d89a-4b15-9de2-767534846e7b"
-    },
-    {
-        "url": "https://www.lianqiai.cn",
-        "title": "链企AI",
-        "type": "web",
-        "description": "链企智能推出的AI商业搜索工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/754fb726-66f3-43d7-9700-53537f8aa5b0.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "58a7d05d-5484-4004-8702-93448c9d4136"
-    },
-    {
-        "url": "https://ask.xiaoyuzhoufm.com",
-        "title": "问问小宇宙",
-        "type": "web",
-        "description": "小宇宙推出的AI搜索产品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe26175d-0743-4a81-af58-02aeb75143c1.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "11fd8bc2-39af-49ca-895e-3afc7d82be0f"
-    },
-    {
-        "url": "https://dexa.ai",
-        "title": "Dexa AI",
-        "type": "web",
-        "description": "AI播客搜索工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/34043fa0-2d7e-4e91-9c3e-9ee1d2a2cf85.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "950a1df5-1bfa-468d-99ee-a161c9d72e14"
-    },
-    {
-        "url": "https://kaisouai.com/",
-        "title": "开搜AI",
-        "type": "web",
-        "description": "面向大众的免费AI问答搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6163b985-4189-4039-a5e4-776f6ea6334a.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "38a17d62-06f9-4250-ac5a-70467a9bd202"
-    },
-    {
-        "url": "https://www.adot.tech",
-        "title": "Adot",
-        "type": "web",
-        "description": "一个由AI驱动的 Web3 搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8e07f8b-1f9f-4f49-9d1c-a623fdc89498.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "9f05f1d2-68d8-418e-8952-dac21caad7de"
-    },
-    {
-        "url": "https://www.xanswer.com",
-        "title": "XAnswer",
-        "type": "web",
-        "description": "支持生成思维导图的免费AI搜索工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8434476d-a934-4d1a-8def-034283926cbb.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "26c99b5f-584f-4894-8404-2e9f1fa4016d"
-    },
-    {
-        "url": "https://www.alpha-sense.com",
-        "title": "AlphaSense",
-        "type": "web",
-        "description": "专为金融专业人士设计的AI搜索工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bafc3e70-4cb8-4c34-96b7-072f4fb8629a.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "5675cc58-ceaa-48bd-8111-ed2e6b1279cf"
-    },
-    {
-        "url": "https://explorer.globe.engineer",
-        "title": "Globe Explorer",
-        "type": "web",
-        "description": "结构化AI知识搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43c8c98e-5035-4d62-9c5b-6d3f965d3e7a.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "65f063c3-6df3-4f61-bf29-5cd43a74975e"
-    },
-    {
-        "url": "https://reportify.cc",
-        "title": "Reportify",
-        "type": "web",
-        "description": "AI投资研究问答搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/117fb7a6-9974-40ad-b685-2e84e103d994.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "f8c3261a-b5cd-49c5-bb41-cde9849d05c4"
-    },
-    {
-        "url": "https://www.phind.com",
-        "title": "Phind",
-        "type": "web",
-        "description": "专为开发者设计的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a08de3ae-fb93-4682-9688-f235e39d21d8.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "b58fdf13-e601-42e1-8159-c9ab5bdb1de6"
-    },
-    {
-        "url": "https://iask.ai",
-        "title": "iAsk AI",
-        "type": "web",
-        "description": "快速准确的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1220e33-4b20-40a0-beb8-2f63057fea45.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "5fd3c716-6926-4b56-931e-fd7429a6a331"
-    },
-    {
-        "url": "https://consensus.app",
-        "title": "Consensus",
-        "type": "web",
-        "description": "AI科研学术搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c061b6c5-018e-47e1-b834-22c243a94895.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "a5da9d32-d9c6-474c-a591-688c206727ab"
-    },
-    {
-        "url": "https://komo.ai",
-        "title": "Komo Search",
-        "type": "web",
-        "description": "简洁直观的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09997be3-f33a-41b7-8142-f4dfaf1c93f8.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "31e0cd6a-28d7-48d7-8293-29b22bc0f84d"
-    },
-    {
-        "url": "https://searcholic.com",
-        "title": "Searcholic",
-        "type": "web",
-        "description": "AI驱动的电子书和文档搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3db37944-b4e0-486e-be9f-8d495e9d7fbb.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "ea68c627-8592-425b-9317-020470c7cedf"
-    },
-    {
-        "url": "https://andisearch.com",
-        "title": "Andi",
-        "type": "web",
-        "description": "对话式人工智能搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/08759ebd-97e2-4379-a894-e9ff7559e597.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "04a57341-ea44-4b7b-8593-7f61f9fe52df"
-    },
-    {
-        "url": "https://www.songtell.com",
-        "title": "Songtell",
-        "type": "web",
-        "description": "AI驱动的音乐百科搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/137cea92-95da-4669-96b8-d281996b26c6.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "9648d516-113f-4881-bebd-d2f6110fabb0"
-    },
-    {
-        "url": "https://thinkany.ai/zh",
-        "title": "ThinkAny",
-        "type": "web",
-        "description": "新时代的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43cdd558-6298-4991-8a83-98727c820923.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "7ac54982-0139-4dd0-b169-f5445f7a1f15"
-    },
-    {
-        "url": "https://www.hellomiku.com",
-        "title": "Miku",
-        "type": "web",
-        "description": "快速精准的搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6df44f0a-e8cb-40c3-90e1-b05b2acac8de.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "7e37a95f-34c8-4fc3-9dad-1c4d41a1508f"
-    },
-    {
-        "url": "https://qdrant.tech",
-        "title": "Qdrant",
-        "type": "web",
-        "description": "开源的向量数据库和向量相似性搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3167d06-940d-4bdd-9b22-b7da8749520b.png",
-        "category": [
-            "搜索引擎"
-        ],
-        "id": "e44ca766-f5d7-4a1f-96ee-ab7bfb1ca979"
-    },
-    {
-        "url": "https://immersivetranslate.com/zh-Hans",
-        "title": "沉浸式翻译",
-        "description": "双语对照的网页翻译插件，完全免费 口碑炸裂！",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5fe5ad13-2cd8-435e-83da-4ceba329c7c1.jpg",
-        "category": [
-            "翻译"
-        ],
-        "id": "4c4aa1e9-7368-4598-8116-445b5e74daa6",
-        "type": "plugin"
-    },
-    {
-        "url": "https://huiyiai.net/",
-        "title": "会译",
-        "description": "沉浸对照式翻译，支持100+语言",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/23389fac-a83d-445c-a8fd-481eec95ea52.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "18e6381a-8eef-4cd0-96b0-a381eae067f6",
-        "type": "web"
-    },
-    {
-        "url": "https://transmart.qq.com",
-        "title": "腾讯交互翻译",
-        "description": "腾讯推出的多语言翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4c8e6aa-b875-4b6e-82c8-5833f5d3c784.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "da9e7ff7-bef6-45a0-a5e7-b70b00a8253d",
-        "type": "web"
-    },
-    {
-        "url": "https://deeptranslate.ai/zh-CN",
-        "title": "DeepTranslate",
-        "description": "免费的AI双语翻译器，支持142+种语言",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a7b50688-869b-42de-8e22-ac12a0012d84.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "f7f8b621-17a8-4690-a5fd-fa45eab0a5a6",
-        "type": "plugin"
-    },
-    {
-        "url": "https://translate.google.com/",
-        "title": "Google翻译",
-        "description": "Google免费提供的上百种语言智能翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/714f695d-58bc-4e5e-a37d-a0d9caf7d819.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "449a7f40-6d4c-451f-a41c-4c7e83ba8668",
-        "type": "web"
-    },
-    {
-        "url": "https://www.bing.com/translator/",
-        "title": "必应翻译",
-        "description": "微软必应推出的翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ce8d6e1a-4744-45ec-9ad1-15f9da10f5c6.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "eab5d132-86cb-4478-937f-fb2d47e93ae2",
-        "type": "web"
-    },
-    {
-        "url": "https://www.deepl.com/translator",
-        "title": "DeepL翻译",
-        "description": "准确的人工智能翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/91666697-0c70-4581-9b6f-6abba2fd4391.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "622ebb49-f9c5-4b92-98b4-4bcd61ad952e",
-        "type": "web"
-    },
-    {
-        "url": "https://www.trytoby.com",
-        "title": "Toby",
-        "description": "AI实时语音翻译工具，专为视频通话设计",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/04c3fb2c-f59c-4529-9f8a-610bca6fac91.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "91fb0ac8-f3a5-4689-bf99-b308241ed4c1",
-        "type": "web"
-    },
-    {
-        "url": "https://translate.volcengine.com/",
-        "title": "火山翻译",
-        "description": "字节跳动推出的智能翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/93e01502-ff8c-4678-8f99-226856d11824.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "3bf21832-ac31-4ebb-bef3-ef25c6d540b0",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.baidu.com/",
-        "title": "百度翻译",
-        "description": "200种语言互译、沟通全世界！",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/69e3adde-0504-4dbe-8264-3ae2ebe0227e.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "64799813-6c8e-4305-862a-294e2b682eda",
-        "type": "web"
-    },
-    {
-        "url": "https://translate.alibaba.com",
-        "title": "阿里翻译",
-        "description": "阿里巴巴达摩院推出的多领域多语种的在线机器翻译",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f729f011-ff5f-4fd4-9210-d20e70782d0c.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "72bbf327-573e-4ca2-95fd-bc0674552e96",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.sogou.com/text",
-        "title": "搜狗翻译",
-        "description": "你的贴身智能翻译专家",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/64c6558e-f6ea-4e16-8a8b-00b3c61f5ec6.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "581eee16-0387-44d9-95cb-73e631e964f9",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.qq.com/",
-        "title": "腾讯翻译君",
-        "description": "你免费的随身翻译",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b898e39e-16d6-442c-8d8c-b95b06c5d180.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "e526af95-1a02-41a8-b6a6-f294504f44af",
-        "type": "web"
-    },
-    {
-        "url": "https://www.xiangjifanyi.com",
-        "title": "象寄翻译",
-        "description": "AI图片和视频翻译神器，支持多种语言的翻译",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cea1d8f1-381f-4bee-b7b7-fe2e5026273e.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "22c5cf2a-46bc-4205-bc2c-71f232d81b3d",
-        "type": "web"
-    },
-    {
-        "url": "https://sight.youdao.com",
-        "title": "网易见外",
-        "description": "网易推出的AI智能翻译平台，支持音视频、文档、图片、字幕等翻译",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/93318218-3f3d-4ab1-9688-e8c27d161f58.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "cbe6f5f4-2445-466c-9857-23ee91e897df",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.xfyun.cn",
-        "title": "讯飞智能翻译",
-        "description": "科大讯飞推出的人工智能翻译平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16547631-38e2-4511-8367-267ad9ae7c9e.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "ba7eae3d-b1cd-4012-9563-b7168083749e",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.caiyunapp.com/#/",
-        "title": "彩云小译",
-        "description": "兼具中日英同声传译、文档翻译和网页翻译的智能翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39f25462-782f-405e-9611-0121cdb4bc8c.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "d234eeb9-f894-4e6c-beb5-3a77b8e3336f",
-        "type": "web"
-    },
-    {
-        "url": "https://fanyi.baidu.com/appdownload/download.html?tab=helper&fr=pcproduct",
-        "title": "百度AI同传助手",
-        "description": "中英文音视频同传字幕工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/309b33bb-990c-4a45-acaa-ac566c985ed9.png",
-        "category": [
-            "翻译"
-        ],
-        "id": "304cfa42-ac20-4ad1-a286-ff4975706d0e",
-        "type": "app"
-    },
-    {
-        "url": "https://www.aippt.cn",
-        "title": "AiPPT",
-        "description": "AI快速生成高质量PPT",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4c8e5d9c-2f19-413a-8af2-a3bd8d6f5a25.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "12c81350-83ac-43d4-8bb4-1245283b3a06"
-    },
-    {
-        "url": "https://www.cappt.cc",
-        "title": "咔片PPT",
-        "description": "AI PPT制作工具，设计美化全流程自动化",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a284ecc-04ab-4690-87fd-51ebc9386379.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "bc903f07-a84e-41ec-a475-553f619e14b0"
-    },
-    {
-        "url": "https://www.bigppt.cn",
-        "title": "笔格AIPPT",
-        "description": "高效的AI PPT生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/198670d2-fdfd-4d21-94a4-a9be92a1f0b9.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "0c47682f-6c34-46f7-b9b6-b972d00ad5f1"
-    },
-    {
-        "url": "https://docmee.cn",
-        "title": "文多多AiPPT",
-        "description": "AI一键生成PPT，支持AI配图和智能资料整合",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/986b7358-5f68-4922-acf9-35ee1c7be44e.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "49178110-81d3-4d6e-b6ea-db0bf962a8c1"
-    },
-    {
-        "url": "https://gamma.app/",
-        "title": "Gamma App",
-        "description": "AI幻灯片演示生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e8301984-bd42-492e-ba0f-401366f3747a.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "275fd305-bfd9-4110-a7a8-d71f01641ad5"
-    },
-    {
-        "url": "https://chatglm.cn/main/alltoolsdetail",
-        "title": "清言PPT",
-        "description": "智谱清言联合AiPPT推出的PPT生成智能体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d3f45c96-1c76-40f3-8899-2d6f88e07611.jpg",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "527e973d-3904-420f-a53f-5e42bfc5179a"
-    },
-    {
-        "url": "https://www.islide.cc",
-        "title": "iSlide AIPPT",
-        "description": "AI一键设计精美PPT，只需一句标题",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c6e6481-a5c6-48ac-8694-3cc87c58d9cf.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "b2470737-fb6a-46f7-b336-e63cea52ddb6"
-    },
-    {
-        "url": "https://www.gaoding.com",
-        "title": "稿定PPT",
-        "description": "稿定推出的PPT模板资源库",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0f1fb71f-b46d-4a38-a0e0-4ad16a54b8b4.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "dd51983b-163d-4041-a9d9-805cf632173d"
-    },
-    {
-        "url": "https://ibiling.cn/ppt-zone",
-        "title": "笔灵AIPPT",
-        "description": "一键生成PPT和千字演讲稿",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/828f97a5-3d3e-4d8f-9a8a-a57c9bb4960d.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "637edd3a-690b-44f2-8f75-85af00381983"
-    },
-    {
-        "url": "https://zhiwen.xfyun.cn",
-        "title": "讯飞智文",
-        "description": "科大讯飞推出的免费AI PPT生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3a5d653e-4f50-452c-96c0-95cdc035842e.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "de1e3a14-0ea7-4392-8d11-1066ee0c4369"
-    },
-    {
-        "url": "https://wenku.baidu.com/ndlaunch/browse/chat",
-        "title": "百度文库AI助手",
-        "description": "基于文心一言的一站式智能文档助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac7fc06c-7907-4124-b1cf-64cb93c80ac9.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "22e2ad34-208a-4877-a40c-025f7b1fab07"
-    },
-    {
-        "url": "https://zhiyan.wondershare.cn",
-        "title": "万兴智演",
-        "description": "万兴科技推出的AI PPT和演示制作软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7f129dd-49dc-4ba7-afc9-6047ba7fdb0e.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "be49321d-cce2-4fae-9616-9a9d216e8cee"
-    },
-    {
-        "url": "https://www.napkin.ai",
-        "title": "Napkin",
-        "description": "将文本内容快速转换成演示图像的AI办公工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/12198477-d272-4dab-8fea-a0e0bdd23987.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "48907b63-91e6-4156-a63c-e970ad5a608c"
-    },
-    {
-        "url": "https://www.visdoc.cn",
-        "title": "VisDoc",
-        "description": "AI文生图表工具，支持生成柱状图、折线图、饼图等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5de01e8-2de6-469e-bbb8-7f6208d144e4.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "6552c4a0-862c-4f5d-8ef9-bef0882cb93b"
-    },
-    {
-        "url": "https://www.designkit.com/ppt",
-        "title": "美图AI PPT",
-        "description": "美图秀秀推出的免费在线AI生成PPT设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee4c6251-e231-43f8-979f-25cbac371590.jpg",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "2d50a420-a620-4d84-8947-91d6443d5baa"
-    },
-    {
-        "url": "https://www.wanzhi01.com",
-        "title": "万知",
-        "description": "零一万物推出的一站式AI文档阅读和PPT创作工作台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aaa68ae9-e9ae-44ed-ab96-38b0c490ccfb.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "7eee2fdc-ccd8-4c99-a872-a800dda99d17"
-    },
-    {
-        "url": "https://gezhe.caixuan.cc",
-        "title": "歌者AI",
-        "description": "彩漩PPT推出的AI PPT生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/566efdfb-1b6d-48cf-b682-cb82ac9d0d84.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "d64b47d1-e587-4f02-a363-f0796ee0b526"
-    },
-    {
-        "url": "https://www.chatba.com/",
-        "title": "ChatBA",
-        "description": "AI幻灯片生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2e2c29b-24b8-49a9-b884-e7d6eaa741cb.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "17c38e8d-6f54-4d76-a3d7-a05d738b4f4a"
-    },
-    {
-        "url": "https://tome.app/",
-        "title": "Tome",
-        "description": "AI创作叙事性幻灯片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5f12d17c-7c43-46ce-bfcf-31cb71c936b5.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "195f97f3-7047-48ce-a84c-7f1d210c41d4"
-    },
-    {
-        "url": "https://www.decktopus.com/",
-        "title": "Decktopus AI",
-        "description": "AI驱动的的在线演示文稿生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82c43066-0205-4575-aeeb-ccd91d9b7a10.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "23dde9b0-c9fb-4a68-959d-4191ee383ea2"
-    },
-    {
-        "url": "https://powerpresent.ai/",
-        "title": "Powerpresent AI",
-        "description": "AI创建精美的演示稿",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20c04ed0-0fe6-4893-a44b-42e9f1c7fe9e.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "57408997-526d-49df-accb-a987fee902a3"
-    },
-    {
-        "url": "https://easinote.seewo.com",
-        "title": "希沃白板",
-        "description": "专为互动教学设计的AI课件生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/85d06107-1464-41a8-be8b-69bc6e089830.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "6f0788d5-08df-4168-8d13-3c9c7e111897"
-    },
-    {
-        "url": "https://10sppt.com/pptx",
-        "title": "秒出PPT",
-        "description": "一键生成PPT，智能辅助编辑",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bb17547d-4074-42c6-a411-ce6f6b21d21b.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "1e517cbe-df8d-4fa7-b04b-92391ab1fa04"
-    },
-    {
-        "url": "https://www.gaippt.com",
-        "title": "GAIPPT",
-        "description": "AI智能美化PPT工具，上传PPT一键美化",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/086fc822-b12f-4cb2-a17e-02fd3b0d708a.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "21ebd126-a5ac-4f46-bf54-9d56f2637c51"
-    },
-    {
-        "url": "https://www.beautiful.ai/",
-        "title": "beautiful.ai",
-        "description": "AI创建展示幻灯片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14f250fe-1762-40dd-af36-d46368d0c787.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "f024bc13-ff64-43a7-a6fc-8ddb432480f3"
-    },
-    {
-        "url": "https://www.mindshow.vip/workstation",
-        "title": "麦当秀MindShow",
-        "description": "AI在线PPT制作工具，支持Markdown等多种格式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8d97253-7735-4400-93d1-bdd4a9482c21.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "7bfe20b1-7a70-4114-a5df-cff5d859cec8"
-    },
-    {
-        "url": "https://www.chat-ppt.com/",
-        "title": "ChatPPT",
-        "description": "AI一键对话生成PPT，智能排版美化",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f366066a-9cac-4ae2-94f8-f19e78d2ae6b.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "74f808cf-d309-4dfd-8fc6-6fe60d1a74cd"
-    },
-    {
-        "url": "https://pptgo.cn",
-        "title": "博思AIPPT",
-        "description": "博思云创推出的在线AI生成PPT工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d3b5fb5-1fad-41a9-87f8-f65fc74c15a9.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "439cbe11-dedf-48ed-9122-9ae2dbdb437a"
-    },
-    {
-        "url": "https://qzoffice.com",
-        "title": "轻竹办公",
-        "description": "在线智能生成和设计PPT的AI工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f1bb6c5-b528-4695-b80f-d9b854330419.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "e36aaca3-611a-499c-a722-be70372d1fa9"
-    },
-    {
-        "url": "https://chroniclehq.com/",
-        "title": "Chronicle",
-        "description": "AI高颜值演示文稿创建",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4dea533-fe0c-4c85-a03e-608a288dc44d.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "7ab4c78c-55b2-4bb6-bfab-0cdef77aa9f4"
-    },
-    {
-        "url": "https://www.presentations.ai/",
-        "title": "Presentations.AI",
-        "description": "演示文档版的ChatGPT",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20f2c45d-0bfc-46bd-948a-462c2eabc246.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "0f1dc28f-fb66-434e-8df0-b13993ab0c0e"
-    },
-    {
-        "url": "https://www.slidesai.io/",
-        "title": "SlidesAI",
-        "description": "AI快速创建演示幻灯片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edde2d9a-02e0-4e34-8f03-1277a3f7e344.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "edf825bd-4cf0-48f7-b798-22a268c45210"
-    },
-    {
-        "url": "https://www.auxi.ai/",
-        "title": "auxi",
-        "description": "功能强大的PowerPoint AI插件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f20d86d-fec6-445e-8538-e1a9b50dff41.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "1377a56f-894c-413c-b9e0-2c0ba0be20ac"
-    },
-    {
-        "url": "https://www.lgppt.cn",
-        "title": "AI灵感PPT",
-        "description": "免费高效的AIPPT生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6c3b82c9-4610-4e8a-a596-ae55bbe03a60.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "201f5e33-c8b6-4d7d-b19a-9aaef87ef2c6"
-    },
-    {
-        "url": "https://www.mindshow.fun",
-        "title": "MindShow",
-        "description": "国内独立开发者开发的输入内容自动生成演示工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fc649f08-a16e-417d-8a9f-730abcef99db.png",
-        "category": [
-            "PPT"
-        ],
-        "type": "web",
-        "id": "5d9da23a-e26d-4eab-8e58-e0bd4e676c9e"
-    },
-    {
-        "url": "https://www.chatexcel.com/#/home",
-        "title": "酷表ChatExcel",
-        "description": "AI Excel 数据分析辅助工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c36b615a-f9d9-46a8-8c0a-5bb07a7cfc43.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "725a6ef0-0b12-437b-8faf-23e861e8ce04"
-    },
-    {
-        "url": "https://www.xiaohuanxiong.com",
-        "title": "办公小浣熊",
-        "description": "商汤科技推出的AI办公助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8180c38b-e3aa-4ce6-8cc8-705f144f9884.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "f53b1f86-3620-472a-ac7d-82cb143fae95"
-    },
-    {
-        "url": "https://vika.cn",
-        "title": "vika维格云",
-        "description": "智能多维表格和数据生产力平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb9432e5-b835-4e29-ac6f-bb1737b9449f.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "ce747325-516d-461c-b0e2-b65b30ec93e0"
-    },
-    {
-        "url": "https://gbi.cloud.baidu.com",
-        "title": "百度GBI",
-        "description": "百度推出的全球商业智能平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c37fc473-045e-4c0a-baff-284e0c0f6519.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "141e6e46-8ac7-442d-9d25-0f17c975a89e"
-    },
-    {
-        "url": "https://ajelix.com/",
-        "title": "Ajelix",
-        "description": "处理Excel和Google Sheets表格的AI工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54a37c98-ee88-499c-9d85-c5b6bb5148f2.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "0f767b31-fe0e-4fae-bdc7-6b3c248718da"
-    },
-    {
-        "url": "https://sheetplus.ai/",
-        "title": "Sheet+",
-        "description": "Excel和Google Sheets表格AI处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/52e04344-429c-473f-8156-32539e889af0.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "4c48a2f7-9b97-4926-8b27-28ec67752b1f"
-    },
-    {
-        "url": "https://cloud.yoo-ai.com",
-        "title": "轻云图",
-        "description": "必优科技推出的AI一键生成可视化云图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/879dd823-acb6-4e5c-911b-f2af856eea8e.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "04807ae6-69ad-4f48-bf54-b57b30d9875b"
-    },
-    {
-        "url": "https://datarc.cn",
-        "title": "北极九章",
-        "description": "北极数据推出的AI数据分析平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8f43b24-a309-436f-8d9e-a8ca43c9a166.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "508d9593-a76d-4620-953c-3179ed44fa88"
-    },
-    {
-        "url": "https://excelformulabot.com",
-        "title": "Formula bot",
-        "description": "AI将指令转换成Excel的函数公式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01594f20-5c66-4c89-9e2a-b21f101e3985.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "e161d8d7-ce36-436a-9d5b-a4010058fb00"
-    },
-    {
-        "url": "https://www.formx.ai/",
-        "title": "FormX.ai",
-        "description": "AI自动从表格和文档中提取数据",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4a9900c-a8a2-436b-bd21-9b998919ac6e.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "624bbdd0-d649-495b-ace4-29b5f0751b32"
-    },
-    {
-        "url": "https://rows.com/",
-        "title": "Rows",
-        "description": "集成了AI功能的在线表格处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/df150d87-027f-4723-9202-b685fe9e2fef.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "0210c12d-8487-4501-89f3-a156a69d377f"
-    },
-    {
-        "url": "https://excelly-ai.io/index.html",
-        "title": "Excelly-AI",
-        "description": "将文本转换成Excel或Google Sheets公式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5ad750c3-5e3a-45ee-8f16-bc98e1983115.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "398f8ae5-2e7c-40ea-85dc-3b1f3b137e3c"
-    },
-    {
-        "url": "https://www.boloforms.com/sheetgod/",
-        "title": "SheetGod",
-        "description": "BoloForms推出的AI Excel公式生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1895ec58-3293-4fa4-87f9-e00ff742e745.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "55b580cf-1405-4a26-be40-15ddd60ab697"
-    },
-    {
-        "url": "https://excelformularizer.com/",
-        "title": "Excel Formularizer",
-        "description": "AI将文本输入转换为Excel公式处理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7667c876-7f59-403d-bc1e-741f45168db7.png",
-        "category": [
-            "表格"
-        ],
-        "type": "web",
-        "id": "f79306d6-9a3c-44b0-8a24-87725bc8ceb7"
-    },
-    {
-        "url": "https://baoyueai.com/channel",
-        "title": "包阅AI",
-        "description": "高效的AI智能阅读助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3df395cd-6118-4d75-8a84-328e5452590d.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "3f94a105-9565-42e5-a166-06443d309567"
-    },
-    {
-        "url": "https://www.txyz.ai",
-        "title": "txyz",
-        "description": "AI文献阅读和学术研究辅助平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80ba9566-28b0-458a-b098-0689d0a0b5cf.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "d87e2538-1628-49ab-965d-cb452b6eba5c"
-    },
-    {
-        "url": "https://noedgeai.com",
-        "title": "Doc2X",
-        "description": "AI文档识别、转换与翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f34ab4aa-8c7d-4e32-969d-846fbb35acc9.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "d450e171-0944-4831-a7ef-4031a9c48744"
-    },
-    {
-        "url": "https://www.adobe.com/acrobat/generative-ai-pdf.html",
-        "title": "Acrobat AI Assistant",
-        "description": "Adobe推出的Acrobat PDF文档AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8af5508-c465-4868-8fc6-fa0b797e5655.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "b7e770d8-bce1-4670-bfde-6959e147bb1e"
-    },
-    {
-        "url": "https://ai.wps.cn",
-        "title": "WPS AI",
-        "description": "WPS推出的AI办公助手，已免费开放",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ba396fb2-0e31-4ff9-8241-75c280cd0ddf.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "016cc4c3-12ac-47d3-a0f0-dba5ce74b84f"
-    },
-    {
-        "url": "https://docs.qq.com",
-        "title": "腾讯文档智能助手",
-        "description": "腾讯推出的AI文档生成和辅助工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5332c89f-92ec-4776-a03f-0cbbf91ac59b.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "15adda4e-8994-4f15-aff1-91864dbdca63"
-    },
-    {
-        "url": "https://cubox.pro",
-        "title": "Cubox",
-        "description": "高效的AI阅读学习助手和信息收集管理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a8ba6c5-8e6c-4d11-880d-775de5d1c6a0.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "1c7aff2f-e6fa-4fc0-8b6b-7f93175227b9"
-    },
-    {
-        "url": "https://www.quivr.app",
-        "title": "Quivr",
-        "description": "开源的知识库搭建工具，构建你的第二大脑",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a1ef919-c109-41cf-8f86-ffc06a673a6c.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "7e94a5c5-e977-498d-b35a-b511f76fbd06"
-    },
-    {
-        "url": "https://coda.io/product/ai",
-        "title": "Coda AI",
-        "description": "在线协作平台Coda推出的AI写作和文档助手，类似于Notion AI",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6bd76e96-0487-4fc7-8d2b-aeaa86ed5392.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "00973ceb-aff9-4394-9a5c-5d84c4d93e6c"
-    },
-    {
-        "url": "https://read.youdao.com",
-        "title": "有道速读",
-        "description": "网易有道推出的AI论文和文档阅读助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/02dc9306-f803-4264-ba0a-e719a1d5567d.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "ef722785-e3f6-4b29-819e-c7aea0386bed"
-    },
-    {
-        "url": "https://wj.qq.com/ai/generate.html",
-        "title": "腾讯问卷",
-        "description": "腾讯推出的AI生成调查问卷的免费工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0d3210f3-d1d0-4a91-90a0-c92277af51e7.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "1827f231-621f-4663-b712-ad25a8e26959"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/zhiwen",
-        "title": "通义智文",
-        "description": "基于通义大模型的AI阅读助手，可智能阅读网页、论文、图书和文档",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1963657f-1a9b-4675-be47-c7a4d47a996b.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "a3994d48-7cf8-4c19-b396-fac692fcfaff"
-    },
-    {
-        "url": "https://getgetai.com",
-        "title": "字语智能",
-        "description": "一站式智能Office内容创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a77e61ca-1a4f-46d3-97a5-647fde1298e5.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "e7af6ae4-91fe-4394-8fed-3f89ee504bff"
-    },
-    {
-        "url": "https://chatdoc.xfyun.cn",
-        "title": "星火文档问答",
-        "description": "基于讯飞星火大模型的AI文档和知识库问答助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79f32d40-673a-49b5-a547-57edf4186095.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "50da344e-2d41-4897-bf10-50556fbeba4b"
-    },
-    {
-        "url": " https://www.pm-ai.cn",
-        "title": "PMAI",
-        "description": "面向产品经理的AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6aa31a7-6d15-4351-b942-a7e0b121c1e2.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "893632a9-686d-4060-853f-7cd7d94fb3f8"
-    },
-    {
-        "url": "https://pdf.ai",
-        "title": "PDF.ai",
-        "description": "AI PDF文档阅读工具，智能文档总结摘要",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/255446fb-e776-4010-a223-7b66c63b4ab7.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "04d4656e-acf2-458c-8fac-5a8bef0c01b5"
-    },
-    {
-        "url": "https://smartread.cc",
-        "title": "司马阅",
-        "description": "AI文档阅读分析工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6f8e3b43-f965-40d8-b8e7-e26094fdd7fc.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "438440b5-a09c-4ab2-924c-a009f4904dd4"
-    },
-    {
-        "url": "https://knowme.xiaoduoai.com",
-        "title": "知我AI",
-        "description": "智能阅读机器人，AI总结文档、网页、视频、播客等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a133838c-dfe0-4bf1-97f4-dcea60581e3b.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "49905916-2f4b-4673-8ea4-92f63b42b908"
-    },
-    {
-        "url": "https://paper.iflytek.com",
-        "title": "星火科研助手",
-        "description": "科大讯飞联合中科院推出的AI科研文献助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e93492b1-bd6f-42db-a6ee-9a7771cf12c7.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "83e345a1-db30-41c2-9884-572c5412fbfd"
-    },
-    {
-        "url": "https://www.yinxiang.com/about/yxai-yxbj/",
-        "title": "印象AI",
-        "description": "印象笔记推出的AI知识和信息管理功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5df18a60-1c44-4871-9bdb-a97bdfb56066.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "47e6ab39-ba94-42ed-af20-70ea33aa83c7"
-    },
-    {
-        "url": "https://www.craft.do",
-        "title": "Craft AI Assistant",
-        "description": "在线文档工具Craft推出的AI文档和创作助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7fbe47f-07f1-4786-a1d9-3891e990e60e.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "17a42f60-9ac8-4ce6-96ff-948c73838c79"
-    },
-    {
-        "url": "https://www.humata.ai/",
-        "title": "Humata",
-        "description": "基于GPT的AI文档分析、阅读和问答工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6f41c8c4-1e03-4dd4-b022-f2661f223688.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "881b155a-02e8-4c97-9e1c-b3b1ca6721c6"
-    },
-    {
-        "url": "http://chatdoc.com",
-        "title": "ChatDOC",
-        "description": "基于ChatGPT的文档阅读、提取、总结、摘要的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3f3b3994-f2d1-43ee-b33d-266d38ad6cac.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "703054c7-322b-489e-aa37-f8844938a6cb"
-    },
-    {
-        "url": "https://www.pandagpt.io/",
-        "title": "PandaGPT",
-        "description": "AI文档要点总结工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dc694990-77c6-4623-bf06-d387258e8fae.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "59658131-3aa1-4544-a247-cbb2ec721c6b"
-    },
-    {
-        "url": "https://rossum.ai/",
-        "title": "Rossum.ai",
-        "description": "现代化的AI文档处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6dd0a980-d444-45bb-beda-de381ad2cc1f.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "1ef2f968-efe7-42fb-81e9-e37f046bf4b5"
-    },
-    {
-        "url": "https://super.ai/",
-        "title": "Super AI",
-        "description": "AI复杂文档自动识别处理转换",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ceedc84-f916-4758-a04c-549c2cba6de8.png",
-        "category": [
-            "文档工具"
-        ],
-        "type": "web",
-        "id": "094a381a-5291-48d4-8576-992639855d53"
-    },
-    {
-        "url": "https://shutu.cn",
-        "title": "TreeMind树图",
-        "description": "新一代AI智能思维导图，一句话生成思维导图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8d0cc96c-b4d7-4e3e-be31-5f5c8fb039bc.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "ea011fec-5d90-4f03-94cd-a587d069adcb"
-    },
-    {
-        "url": "https://boardmix.cn/ai-whiteboard",
-        "title": "博思白板",
-        "description": "博思云创推出的AI多功能白板工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/97cf28fb-287b-46d7-885e-0ae8bc5a2dc2.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "0e3aedd5-db50-485d-8796-a3d4e2705a31"
-    },
-    {
-        "url": "https://www.processon.com",
-        "title": "ProcessOn",
-        "description": "在线AI流程图和思维导图制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c59a0071-7dba-4677-9526-426683a1df60.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "c52e47dc-9901-49e8-a62e-19efded3c11e"
-    },
-    {
-        "url": "https://wenku.baidu.com/pcactivity/freeBoard",
-        "title": "自由画布",
-        "description": "百度文库和百度网盘联合推出的AI万能白板",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3768413a-5eba-4c5c-86a1-c95b50b03a3a.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "6720b3f4-7c82-4255-bc5d-5771ed2cbf51"
-    },
-    {
-        "url": "https://www.edrawsoft.cn/mindmaster",
-        "title": "亿图脑图",
-        "description": "亿图脑图思维导图助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/140fa2dc-21f1-488e-9762-9938f0faf076.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "5e018511-bb00-40ef-9fd1-e0930752d5ec"
-    },
-    {
-        "url": "https://imiaoban.com",
-        "title": "妙办画板",
-        "description": "在线实时协作的画图工具，AI一键生成流程图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f431309b-2a9e-4e4e-a067-1c3d066418f9.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "1aedbe19-3944-40e5-8a8e-a5c22da705cf"
-    },
-    {
-        "url": "https://mapify.so/cn",
-        "title": "Mapify",
-        "description": "Xmind推出的思维导图生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/074fcfe7-8058-4c63-a239-eb8163f4ba91.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "3bca3a14-e081-458a-b8b2-b887104e81d3"
-    },
-    {
-        "url": "https://www.xiaohuazhuo.com",
-        "title": "小画桌",
-        "description": "在线协作白板工具，内置AIGC功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ed22ebf7-e6c4-420a-8be2-ca679f165b3c.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "5016c01e-610f-416c-bdcb-a0b301f6cf6f"
-    },
-    {
-        "url": "https://www.yinxiang.com/product/evermind/",
-        "title": "印象图记",
-        "description": "印象AI加持的在线思维导图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a1bdcf8b-df2b-4637-a52f-d2c89f85fdde.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "11f5aec8-314c-4efc-a861-02b755cbd3e4"
-    },
-    {
-        "url": "https://www.swdt.com",
-        "title": "知犀AI",
-        "description": "知犀推出的思维导图生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c590132-6869-458c-a723-04698f833a4f.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "bced0743-092f-4af6-900f-d631cf44fcb1"
-    },
-    {
-        "url": "https://xmind.ai",
-        "title": "Xmind Copilot",
-        "description": "Xmind 思维导图助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a2a85a9-5880-45a6-a9f4-8a48b03c4baf.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "e5f90b6c-f58c-49fb-984a-bbf8877e3dc2"
-    },
-    {
-        "url": "https://imiaoban.com/work/AIht",
-        "title": "妙办AI画图工具",
-        "description": "AI免费一键生成流程图、思维导图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8f0cfc20-a963-401a-be05-cda305af819c.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "8b1a6125-e6e6-443e-af0f-8cf81d4ecdc0"
-    },
-    {
-        "url": "https://gitmind.cn",
-        "title": "GitMind思乎",
-        "description": "AI驱动的免费思维导图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cc507600-2e6c-4efc-aeb2-d95fa1dbea3c.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "d4cef4c1-577a-491a-af58-43a5b8af3b9e"
-    },
-    {
-        "url": "https://www.edrawsoft.cn/edrawmax/ai",
-        "title": "亿图图示AI",
-        "description": "专业的办公绘图软件，轻松绘制图表和图形",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8d1da4b-5d28-4ef5-b6ac-88d8ea487721.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "d577db3c-ac8a-43e5-978d-be2863e8f919"
-    },
-    {
-        "url": "https://whimsical.com/ai-mind-maps",
-        "title": "Whimsical",
-        "description": "Whimsical推出的思维导图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a4748e7-aac1-48a9-80de-c6f202b210fb.gif",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "6f93fd7e-caa2-4f19-ba13-cc76567b6176"
-    },
-    {
-        "url": "https://amymind.com",
-        "title": "AmyMind",
-        "description": "开箱即用的在线思维导图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/62fb368c-93d2-41a1-95a9-a8442cb31db0.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "8ef3ff95-df77-4ebe-ab0a-47c0bb28d9a6"
-    },
-    {
-        "url": "https://www.taskade.com/",
-        "title": "Taskade",
-        "description": "高颜值AI大纲和思维导图生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/411bdd6b-0940-4207-bf99-67bf71fa380c.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "4e04d3a8-8db0-4cd1-aa84-00fbf7449fb0"
-    },
-    {
-        "url": "https://miro.com/mind-map/",
-        "title": "Miro AI",
-        "description": "在线白板协作工具推出的AI功能，Beta测试中",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4b96964-613e-47b3-989d-8d523f75c23b.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "40b80c4a-78c7-4bf6-966e-6eb15c0d5d65"
-    },
-    {
-        "url": "https://www.ayoa.com/ultimate/",
-        "title": "Ayoa Ultimate",
-        "description": "思维导图和头脑风暴工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6545320-7dfc-4d7b-9108-d7af2a5bb675.png",
-        "category": [
-            "思维导图"
-        ],
-        "type": "web",
-        "id": "8f6d1c2a-f1c2-41e5-8f81-28cb5cf74055"
-    },
-    {
-        "url": "https://itingnao.com",
-        "title": "听脑AI",
-        "description": "人工智能语音录音记录助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/36e91984-7694-4e55-b898-90e4e8d14d69.png",
-        "category": [
-            "会议工具",
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "49a98b04-ce09-4cda-9dd9-043d01385056"
-    },
-    {
-        "url": "https://pan.baidu.com/embed/listennote",
-        "title": "简单听记",
-        "description": "百度网盘推出的AI语音转文字工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3dabd275-e5e6-44f9-a0f0-dd2231c61dde.png",
-        "category": [
-            "会议工具",
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "d0ebe59b-db52-4f7a-9016-2f7d05971404"
-    },
-    {
-        "url": "https://tingwu.aliyun.com",
-        "title": "通义听悟",
-        "description": "阿里推出的AI会议转录工具，万语千言，心领神悟",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/22068cb7-96f5-4360-8624-4d8a890339f3.png",
-        "category": [
-            "会议工具",
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "e5104e6a-200b-422c-a827-e2a3c55f316b"
-    },
-    {
-        "url": "https://meeting.iflyrec.com",
-        "title": "讯飞会议",
-        "description": "AI智能会议系统，实时字幕、实时翻译、自动生成会议记录",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bc8b123-3acf-41ab-bc70-011764b8194a.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "app",
-        "id": "e7edfee3-7273-4ee6-9138-4e64418e2446"
-    },
-    {
-        "url": "https://www.feishu.cn/product/minutes",
-        "title": "飞书妙记",
-        "description": "飞书智能会议纪要和快捷语音识别转文字",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6c87cd8c-c270-43bc-aba0-219b6bcfb8cc.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "c6f24889-3d24-485d-ac58-bd30c2c2574a"
-    },
-    {
-        "url": "https://otter.ai",
-        "title": "Otter.ai",
-        "description": "AI会议内容生成和实时转录",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5d931953-f65e-417e-975a-9cfbb8ee2365.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "94dcb0e9-80f9-49a7-8717-ad6a7477525a"
-    },
-    {
-        "url": "https://meeting.tencent.com/ai",
-        "title": "腾讯会议AI小助手",
-        "description": "腾讯会议推出的AI会议内容助理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/77f8d144-2957-4279-a566-f01f9f020f65.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "c6f7826a-932f-4559-b353-56e858fc3991"
-    },
-    {
-        "url": "https://www.zoom.com/zh-cn/products/collaboration-tools/",
-        "title": "Zoom Workplace",
-        "description": "Zoom推出的AI办公协作和交流沟通平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f42c894-84d4-49d4-8141-e306f0752985.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "65339807-30c0-4a8a-b4e0-c599d77be98b"
-    },
-    {
-        "url": "https://work.duiopen.com",
-        "title": "麦耳会记",
-        "description": "思必驰推出的AI会议助手，语音转文字、字幕同传、AI摘要",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f0b8e53-9e42-4f79-9106-6d5b3d973add.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "15c953c7-6492-45ba-b1f8-a27274fbfd87"
-    },
-    {
-        "url": "https://fireflies.ai/",
-        "title": "Fireflies.ai",
-        "description": "AI会议转录和会议纪要生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d794e54-2ebc-4e36-9e9d-0fc109eddeab.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "e430e590-caea-49e1-a87c-ebb43f57124f"
-    },
-    {
-        "url": "https://noty.ai/",
-        "title": "Noty.ai",
-        "description": "ChatGPT驱动的AI会议转录工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/808ebc45-38c8-428c-ad97-0387744c9aae.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "e84d07a8-d76b-494e-bfc6-9e2567059bac"
-    },
-    {
-        "url": "https://www.airgram.io",
-        "title": "Airgram",
-        "description": "自动会议笔记和总结的AI助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/933c8113-b725-48aa-ae61-5a325f4488ec.png",
-        "category": [
-            "会议工具"
-        ],
-        "type": "web",
-        "id": "e0532822-0537-4868-a9f3-06a6041c65e9"
-    },
-    {
-        "url": "https://offergoose.cn",
-        "title": "多面鹅",
-        "description": "免费大厂面试模拟器，线上面试答案提词器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/37cd65ef-1a0d-40fd-ac33-80fb34d51089.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "d4f9ebeb-2b16-4fb6-8c2e-ed378a1c9d3a"
-    },
-    {
-        "url": "https://mercor.com",
-        "title": "Mercor",
-        "description": "招聘求职求职平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9f6a0b3-e141-4f2f-ae6e-813210b8e7b9.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "93511733-0fa5-4f92-a7d9-d9d9048e02ee"
-    },
-    {
-        "url": "https://www.offerin.cn",
-        "title": "Offerin",
-        "description": "AI面试笔试助手，精准识别面试问题秒级生成答案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2c168795-cdc5-42be-a727-f3394d6ffee6.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "c4a82d36-5234-458a-8c60-efb4ce6bce0b"
-    },
-    {
-        "url": "https://aiqtools.cn",
-        "title": "智面星",
-        "description": "AI面试辅助工具，提供全流程的面试辅助",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f865aa29-4054-4782-a756-be39c43b934a.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "app",
-        "id": "1a033649-21b2-4255-9add-177ded01bb4e"
-    },
-    {
-        "url": "https://m.baigua.com",
-        "title": "白瓜面试",
-        "description": "在线AI面试助手，快速生成面试问题的答案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a4faff1-a7a5-4d0b-bd45-d4c2e507c5e0.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "977ba3a3-9922-4b91-9d0e-ae9a3752bc2c"
-    },
-    {
-        "url": "https://www.52cv.com",
-        "title": "职徒简历",
-        "description": "智能简历制作软件，基于GPT的简历优化和简历代写",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ea6b1959-ce04-41dd-800e-ab7c2f841cf3.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "67a116d9-9756-4ee7-9d31-e87d28fe1225"
-    },
-    {
-        "url": "https://www.zdjianli.cn",
-        "title": "职得简历",
-        "description": "在线AI简历生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c39f2020-5f8f-49dd-a686-3c4fe2690b1d.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "dc5bcf3a-e690-42af-9a0a-aea544b717cf"
-    },
-    {
-        "url": "https://www.lanzidian.com",
-        "title": "蓝字典AI求职",
-        "description": "AI求职工具，提供AI简历生成、AI模拟面试服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54419678-9a22-4660-9806-40ef75a973db.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "c1ee1a76-e189-4aac-b59f-0e5437c68faa"
-    },
-    {
-        "url": "https://jianli.jiuyeqiao.cn/#/index/index",
-        "title": "神笔简历",
-        "description": "AI简历云平台，专为求职者提供一站式求职服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54b42a85-b07c-4988-9ec9-c4b33b9a668b.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "3be7285d-6f9c-47fc-8e10-61dc2b71a0a6"
-    },
-    {
-        "url": "https://www.yoojober.com",
-        "title": "YOO简历",
-        "description": "必优科技推出的AI简历生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e1a4c1da-4b0a-4834-a6d3-0a701cbfec5e.png",
-        "category": [
-            "招聘求职求职"
-        ],
-        "type": "web",
-        "id": "f37a1fc2-9c56-4af3-aa86-719c5b247a05"
-    },
-    {
-        "url": "https://www.feishu.cn/paid/ai-register",
-        "title": "飞书多维表格",
-        "description": "表格形态的 AI 工作流搭建工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/239a1bc7-48c9-4800-8085-e30e58579f18.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "3fd60151-d469-46b7-9005-fe0c26b60cce"
-    },
-    {
-        "url": "https://manus.im",
-        "title": "Manus",
-        "description": "Monica团队推出的全球首款通用型 AI Agent",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c9a9a58-0c29-4b69-9d0a-010511abd3e9.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "e9c5551d-f348-46c5-a6b6-f9bf5ac804a1"
-    },
-    {
-        "url": "https://tinywow.com/",
-        "title": "TinyWow",
-        "description": "免费在线AI工具箱",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/17051054-f2ba-4494-96bf-f9ef6787cf31.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "005099f5-790f-4180-90ac-d456b3ba44d3"
-    },
-    {
-        "url": "https://ima.qq.com",
-        "title": "ima.copilot",
-        "description": "腾讯推出的AI智能工作台产品，基于混元大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8400332-9f00-41d7-a9ac-d098638be3a2.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "dc0cc7cb-5f39-4f4d-800a-66f06a7bf463"
-    },
-    {
-        "url": "https://ask.feishu.cn/topic",
-        "title": "飞书知识问答",
-        "description": "飞书智能办公推出的AI知识库工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f62f59ce-3f90-40fa-81d4-b0b6d2b2ad9e.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "0c0ebe2e-2c9f-415a-8172-c8dade840067"
-    },
-    {
-        "url": "https://monica.cn",
-        "title": "Monica",
-        "description": "全能AI助手，提供聊天、搜索、写作、翻译等多功能服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f500aac-d695-4851-be8c-e2ca1a0d87f5.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "15ac6e1a-8ad9-47be-a43d-2fb05accb226"
-    },
-    {
-        "url": "https://lingxi.wps.cn",
-        "title": "WPS灵犀",
-        "description": "WPS推出的AI办公助手，支持PPT生成、AI写作",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81269afc-60b3-4aec-85e7-fbc19fb08ef9.jpg",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "58589f14-e572-44ff-9df3-6b9f1e73ef43"
-    },
-    {
-        "url": "https://glif.app",
-        "title": "Glif",
-        "description": "无代码的AI小工具构建平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4ed96ba-e3de-464c-9f6c-433df9ff9d7c.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "2198fb76-5411-41b4-9441-8520114e70ec"
-    },
-    {
-        "url": "https://qimi.com",
-        "title": "奇觅",
-        "description": "美图推出的游戏广告AI制作与投放平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5cb587ba-8f73-4106-b2e5-b16068122e54.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "96ab36b3-a4a7-4816-9493-097ee4e6b246"
-    },
-    {
-        "url": "https://pan.baidu.com/aipan/welcome",
-        "title": "云一朵",
-        "description": "百度网盘最新推出的智能助理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8eedc29f-6dd0-404d-8e9f-eeeb5ac06a66.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "3c8629b9-630c-453f-8c1c-972a495e681d"
-    },
-    {
-        "url": "https://bangong.360.cn",
-        "title": "苏打办公",
-        "description": "360公司推出的一站式AI办公工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/840eae23-e1ae-426a-97d8-1564aee3981b.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "bb298e52-f882-4583-98c3-9dec0e875bab"
-    },
-    {
-        "url": "https://hoarder.app",
-        "title": "Hoarder",
-        "description": "开源的基于AI的书签和个人知识库管理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2fbfb9c9-235e-4706-adc0-1332d859b700.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "89e90a62-ceee-4b93-90f4-dcba0c7f367e"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/xiaomi",
-        "title": "通义晓蜜",
-        "description": "阿里推出的企业智能服务解决方案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ee49bf4-5f8f-4aea-916d-87288cdf6f07.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "8a1473fd-9602-4535-9e31-cc41d16db9c4"
-    },
-    {
-        "url": "https://aiask365.com",
-        "title": "奇妙问",
-        "description": "企业AI数字员工生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3b7121f0-faa4-42d3-94a9-e9bd7c477bb0.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "dfebdd68-25c9-4d28-ad85-db98f6586dc7"
-    },
-    {
-        "url": "https://notebooklm.google",
-        "title": "NotebookLM",
-        "description": "谷歌推出的AI笔记应用，5分钟生成一段对话播客",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/26d2ca6e-635b-48c9-92fc-730845912726.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "25514259-930f-4b2c-b5ba-0a56f92347d5"
-    },
-    {
-        "url": "https://www.yingdao.com/ai-power",
-        "title": "影刀AI Power",
-        "description": "面向企业的无代码AI开发和集成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee6861d5-aa80-4fd4-b5f7-a7ccdad337e6.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "7009ac02-fba1-464d-be7f-64afedcd0149"
-    },
-    {
-        "url": "https://www.tongdaai.com",
-        "title": "通答AI",
-        "description": "企业AI数字员工生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ffa2c5fd-bb89-42e4-bb9b-024a7a1ea6e6.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "080e3121-c219-479e-96e3-be4fff4c5d88"
-    },
-    {
-        "url": "https://smartchoose.cn",
-        "title": "司马诸葛",
-        "description": "企业级AI数字员工平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a31985e-4f7e-4f55-a6bd-a2924e499c4e.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "5e8c9a8a-8c34-47fc-bfc7-fd70c1ac9b4c"
-    },
-    {
-        "url": "https://www.kaopuai.com",
-        "title": "靠谱AI",
-        "description": "无代码AI机器人创建平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/61481e48-8b89-4a47-ab93-19ecc6764f17.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "9a8a8119-c9fb-425d-8964-e1355f4f1c26"
-    },
-    {
-        "url": "https://www.salesforce.com/einsteincopilot",
-        "title": "Einstein Copilot",
-        "description": "Salesforce推出的CRM系统AI对话助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3c12bbfc-4138-4835-a628-ea8f424661a2.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "5cb75403-cc8f-4edd-8f0a-2bf7e379a60f"
-    },
-    {
-        "url": "https://zapier.com/ai",
-        "title": "Zapier AI",
-        "description": "Zapier推出的AI自动化集成功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0b9c723-dbee-429c-9f54-8e5e0366c4d1.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "09f658c8-982c-450c-b670-674891a03de5"
-    },
-    {
-        "url": "https://www.guaishouai.net",
-        "title": "怪兽AI知识库",
-        "description": "企业知识库大模型 + 智能AI问答机器人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4cbd8c6f-c858-46c9-8c31-02725278a52a.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "d6285f11-74fa-4878-b042-123b7e21242e"
-    },
-    {
-        "url": "https://www.tukuppt.com",
-        "title": "熊猫办公",
-        "description": "AI办公服务平台，提供PPT模板、Excel模板、Word模板等资源",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aa8432a5-8a3c-4ca5-a9e8-d77422966b47.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "aeb2062b-1586-4f89-a1ae-ebf83e28495b"
-    },
-    {
-        "url": "https://ai.eqxiu.com",
-        "title": "小易AI",
-        "description": "易企秀推出的AI办公工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee9ca30c-ac56-459e-b0fb-28ae2c6d1f70.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "28ef8312-c827-4e3d-b8ae-7e0c269ec14c"
-    },
-    {
-        "url": "https://merlin.foyer.work/",
-        "title": "Merlin",
-        "description": "基于ChatGPT的Chrome浏览器扩展，浏览任意网页时利用GPT",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9c063db5-f158-4dae-a9e4-f285e3d005ff.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "d52db46a-557c-421a-ac85-764ab2fdb21f"
-    },
-    {
-        "url": "https://www.raycast.com/ai",
-        "title": "Raycast AI",
-        "description": "Raycast推出的Mac AI助手，智能写作、编程、回答问题等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/730e9380-b2a7-4711-b8cb-8792dbc177ce.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "b5aa4004-fbb2-40d1-b5cf-8e8312503d14"
-    },
-    {
-        "url": "https://timelyapp.com/",
-        "title": "Timely",
-        "description": "AI时间管理跟踪软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/548aece4-3547-4d2c-b053-90a4469d9540.png",
-        "category": [
-            "效能工具"
-        ],
-        "type": "web",
-        "id": "5611953a-4f99-4ed0-a5be-c4bf3077dcef"
-    },
-    {
-        "url": "https://ihuiwa.paluai.com",
-        "title": "绘蛙",
-        "description": "AI电商营销工具，免费生成商品图和种草文案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe86d13d-71ea-43c5-a829-c6b17a8deb40.png",
-        "category": [
-            "图像工具",
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "730d29d2-b049-456e-a7cb-19c5477a6622"
-    },
-    {
-        "url": "https://www.meijian.com/e-commerce",
-        "title": "美间AI",
-        "description": "免费设计工具助手，智能海报、提案和商品图生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/068effba-371f-4e05-a54d-2d33150a8b9f.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "04da8ad1-b5c3-47d1-9529-619924367df2"
-    },
-    {
-        "url": "https://www.gaoding.com",
-        "title": "稿定AI",
-        "description": "一站式设计工具集，免费AI绘图、图片转AI绘画、AI抠图消除",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfabe83e-d50c-410b-be91-e96da7a4553a.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "cc6cfdbe-c07e-49a8-b1c5-660a27b7377f"
-    },
-    {
-        "url": "https://www.recraft.ai",
-        "title": "Recraft AI",
-        "description": "免费无限AI画板，生成高质量矢量艺术画、图标、3D图片和插画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09f908f4-4619-47d2-abfe-946b83d65f7e.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "59454d99-7ec2-4120-8946-14b870837fda"
-    },
-    {
-        "url": "https://www.piccopilot.com/create",
-        "title": "Pic Copilot",
-        "description": "阿里国际推出的AI电商设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8c11807f-e416-42be-a5d1-7f650005bb16.png",
-        "category": [
-            "设计工具",
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "dfade468-ce55-4539-8454-e3436dc605c2"
-    },
-    {
-        "url": "https://aiart.chuangkit.com/matrix",
-        "title": "创客贴AI",
-        "description": "AI辅助的智能在线设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81891aae-6101-454a-80dd-523dda7ec8f1.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "ce9cb362-34a3-433e-8f0e-5066941346bb"
-    },
-    {
-        "url": "https://www.designkit.com/tools",
-        "title": "美图设计室",
-        "description": "AI图像创作和设计平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a9d43c53-8d03-4e20-aac0-60414275d05e.jpg",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "c42ba6d1-93ac-4e3b-b7bc-5c303869a22a"
-    },
-    {
-        "url": "https://www.figma.com/ai",
-        "title": "Figma AI",
-        "description": "Figma推出的原生设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/65f02069-f42d-4397-ba3d-4a8d99800f8e.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "a5aad96b-b266-4034-9314-d41158c83db3"
-    },
-    {
-        "url": "https://idesign.alipay.com",
-        "title": "蚂上有创意",
-        "description": "支付宝推出的设计工具，面向商家提供电商设计服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6d178820-134b-4027-940f-52be153277b3.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "68024488-e45f-4e9c-8aba-ee09f59fd2f1"
-    },
-    {
-        "url": "https://www.isheji.com",
-        "title": "爱设计",
-        "description": "AI在线设计平台，提供多端在线拖拽设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a1234bb-9e02-4cb7-8c84-434a4e90da14.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "8c5cfc9e-263f-49a4-a8b3-5a2f8530372b"
-    },
-    {
-        "url": "https://www.canva.cn/magic",
-        "title": "魔力工作室",
-        "description": "Canva可画推出的一站式AI创作套件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a0a6a9c-3760-4bfd-8a60-0e0094000d7a.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "ef613bcb-6cf4-4fdd-bff3-dd18a8785ca6"
-    },
-    {
-        "url": "https://designer.microsoft.com/",
-        "title": "Microsoft Designer",
-        "description": "微软推出的在线设计海报和宣传图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4bc3baea-fee4-4bd7-8074-a9f9db973683.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "010942fa-ad5a-4dbc-820a-530236150b90"
-    },
-    {
-        "url": "https://onlook.com",
-        "title": "Onlook",
-        "description": "开源AI视觉编辑工具，设计修改自动同步代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ce90d806-55a5-4214-9f3c-dbeb3fa1f5ff.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "76385647-b78c-4890-99cb-0b367b6914fe"
-    },
-    {
-        "url": "https://looka.com/",
-        "title": "Looka",
-        "description": "AI在线设计和生成logo",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1bb8034f-c829-46bd-8a45-036bf3d5abb1.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "2c30eb03-6e95-4bb6-90e0-139728962ae0"
-    },
-    {
-        "url": "https://taishan.qq.com/brand",
-        "title": "智绘设计",
-        "description": "腾讯推出的智能设计平台，让内容更精彩",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8b04865b-056c-4117-a82d-05587bd862e7.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "6443843b-402c-4427-9852-eca372f44282"
-    },
-    {
-        "url": "https://mastergo.com/upcoming-ai/apply",
-        "title": "MasterGo AI",
-        "description": "国产产品设计工具MasterGo推出的智能UI设计助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/caadacd9-a069-4ccd-b569-7fae55cb8ba8.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "639e8858-d3fd-4ed6-a254-8091c7b89391"
-    },
-    {
-        "url": "https://modao.cc/feature/ai.html",
-        "title": "墨刀AI",
-        "description": "墨刀推出的AI产品原型设计助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ae3b1bb0-a4b5-49f4-a68d-9f404f1fc86c.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "f2e5167d-91b5-40ca-acb9-fa8ef665f4cd"
-    },
-    {
-        "url": "https://ibihun.com",
-        "title": "笔魂AI",
-        "description": "设计工具，支持AI抠图、消除、无损放大",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f9b9475e-9404-4d98-ab84-0ae201b55c23.png",
-        "category": [
-            "设计工具",
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "dfa4b91a-4da7-4195-b70e-d09e2b1a3795"
-    },
-    {
-        "url": "https://www.shejijia.com",
-        "title": "居然设计家",
-        "description": "居然之家联合阿里推出的AI家装设计平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84015aa4-f912-410a-a0ca-485690f25199.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "e7d33ad3-6b0c-42bd-8a44-c5e0b68c751b"
-    },
-    {
-        "url": "https://www.figma.com/figjam/ai/",
-        "title": "FigJam AI",
-        "description": "Figma推出的AI白板协作设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/416549c1-d6c4-474c-a43c-81104045216a.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "b667a7d0-4215-42c9-811c-bf115ac4924d"
-    },
-    {
-        "url": "https://luban.aliyun.com",
-        "title": "鹿班",
-        "description": "阿里推出的智能设计商品图和海报的平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96b5b331-b2e5-4278-acf0-c0fe3d9bf4d3.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "9db86e71-a9b1-4a71-a387-25a32632b8b6"
-    },
-    {
-        "url": "https://www.canva.com/magic-design/",
-        "title": "Magic Design",
-        "description": "在线设计工具Canva推出的设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e0f52ac-b040-4e9f-904c-49c554e67acd.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "80bf8c37-c267-491b-a56b-c69b9b4a50b1"
-    },
-    {
-        "url": "https://www.jiandan.link",
-        "title": "简单设计",
-        "description": "免费的在线设计、图片处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5bbf9ae-b2d2-4f9f-9b0e-4948dd40ac2c.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "a06ba857-0f5d-4534-9df9-695f4be6a2c7"
-    },
-    {
-        "url": "https://www.135editor.com/ai_editor",
-        "title": "135 AI排版",
-        "description": "公众号AI图文排版和智能文案生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38e2bd3f-9d33-4287-bdca-a74a358421c9.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "b039410e-faf2-423d-ba54-32581ab0a1cb"
-    },
-    {
-        "url": "https://bigesj.com",
-        "title": "笔格设计",
-        "description": "设计工具合集，包括文生图、智能消除等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e246b055-4c15-4bed-bbfa-ec393e89e6cb.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "01d08ab5-e37e-4b11-9046-1c79024863cd"
-    },
-    {
-        "url": "https://www.logoai.com",
-        "title": "Logoai",
-        "description": "AI LOGO创建设计平台，一站式品牌打造",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f3b33f0-44d6-499c-b43f-953f890a080a.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "e0858f3c-5ab2-4310-9a23-c33b7353eafb"
-    },
-    {
-        "url": "https://www.douhuiai.com",
-        "title": "豆绘AI",
-        "description": "AI绘图设计平台，一键生成720°VR全景图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/98a3785b-bc92-4bde-8edd-05b6da8094b1.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "116869c2-5960-45ab-8516-3366d32ab772"
-    },
-    {
-        "url": "https://www.58pic.com/",
-        "title": "千图网",
-        "description": "在线设计图片素材平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3fb60727-f913-4bce-a583-b050e0218de1.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "af579f42-2b15-4a39-a343-ea195bd04bf1"
-    },
-    {
-        "url": "https://pictographic.io",
-        "title": "Pictographic",
-        "description": "AI插图资源库和生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0cd8a103-3784-42f1-87f2-b63b1cafc592.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "4318d11a-ca8b-4d2d-b36e-d2aea8314e68"
-    },
-    {
-        "url": "https://www.fable.app/prism",
-        "title": "Fable Prism",
-        "description": "AI动效设计和动画效果制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be50d7c8-c2e6-495e-8aaa-ebaca365d532.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "82b83d2a-ece6-430f-a745-7e1aa17c76fa"
-    },
-    {
-        "url": "https://wegic.ai",
-        "title": "Wegic",
-        "description": "AI网页设计和建站开发工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7734da6c-d1cb-48ea-9b4c-336ee22a1f61.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "6ced90ad-b7b8-480a-bc01-f63123e5d79f"
-    },
-    {
-        "url": "https://jiangziai.com",
-        "title": "匠紫",
-        "description": "一站式设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be43426a-467b-4e22-bcc8-c112601f6c77.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "638f4a50-2e2b-4b00-ae70-efbf81f692a2"
-    },
-    {
-        "url": "https://collov.cn",
-        "title": "Collov AI",
-        "description": "AI室内家居设计生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2632a5c-c44c-4052-bfbb-06ebde31af33.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "5c5a5ebe-3811-465b-9719-e9fef06a7755"
-    },
-    {
-        "url": "https://ibaotu.com/tupian/shuziyishu.html",
-        "title": "包图网AI素材库",
-        "description": "包图网提供的特色图库服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/41d2c2cc-edc7-42df-850c-168a87159b38.png",
-        "category": [
-            "设计工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "bc6b5758-570f-4a67-bb66-4e6983001574"
-    },
-    {
-        "url": "https://www.yiketu.com",
-        "title": "易可图",
-        "description": "免费的AI图片编辑和海报设计平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c58ef99b-67b8-4ffb-87e8-44065ad5f30a.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "42cad10a-efc5-489b-aee1-a180f3bae306"
-    },
-    {
-        "url": "https://creatie.ai",
-        "title": "Creatie",
-        "description": "AI驱动的UI和UX设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/512fd938-e8a4-4798-b58d-14fd0834ebd3.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "484e7964-4a15-4639-90ce-18df9e4cb48f"
-    },
-    {
-        "url": "https://www.kittl.com",
-        "title": "Kittl",
-        "description": "AI驱动的平面图形设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8b752d3-a645-4db3-bc89-e1d2ce362d52.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "e6d7f424-85a7-4783-9573-00ec87bc0fbc"
-    },
-    {
-        "url": "https://www.dzine.ai",
-        "title": "Dzine",
-        "description": "一站式AI图像编辑和设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/571ed08b-508f-443d-9f44-a29b914a9f25.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "40eb4768-757b-4570-9809-8bfca6ea5604"
-    },
-    {
-        "url": "https://ilus.ai",
-        "title": "Ilus AI",
-        "description": "AI插画插图生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4f951923-2344-4c46-ad79-eae7bf8defbd.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "bdeff769-f560-4748-af56-e6e31150c32e"
-    },
-    {
-        "url": "https://illustro.app",
-        "title": "Illustro",
-        "description": "AI illustration generator and editor with flat, line art, children's book, and 3D styles",
-        "image": "https://illustro.app/logo/illustro-logo.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "a8f3c2e1-4b5d-4a9e-9c7d-1e2f3a4b5c6d"
-    },
-    {
-        "url": "https://www.kujiale.cn/activities/AI-kujiale",
-        "title": "酷家乐AI",
-        "description": "功能强大的AI家居设计软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e7a7085a-8d59-401c-b208-cf8831cd1715.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "0f94628f-7430-474f-bff0-6467b4743bb8"
-    },
-    {
-        "url": "https://pixso.cn",
-        "title": "Pixso AI",
-        "description": "国产在线设计工具Pixso的内置AI助手，支持AI文生图、AI对话、AI设计等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24a89c9a-6773-4982-a6ff-b739c037a5ad.jpg",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "6b62d695-8957-4ae6-9281-4159fd1d1a8f"
-    },
-    {
-        "url": "https://www.framer.com/ai",
-        "title": "Framer AI",
-        "description": "Framer推出的AI网站自动设计、生成和上线",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bb3cfee-6bf9-4058-9be5-1b7feb8b5463.png",
-        "category": [
-            "设计工具"
-        ],
-        "type": "web",
-        "id": "0da2979a-333c-4cb8-8798-e76e83f04eb2"
-    },
-    {
-        "url": "https://www.trae.com.cn/",
-        "title": "Trae",
-        "description": "字节跳动推出的免费编程工具，基于Claude模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/966a6461-ee44-4f70-8f07-c690db36e115.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "0cdcc48d-23e3-423a-9848-1968ed9350ae"
-    },
-    {
-        "url": "https://click.aliyun.com",
-        "title": "通义灵码",
-        "description": "阿里推出的免费编程工具，基于通义大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/db98f40b-2d4e-463e-a42b-0b4f120bb89d.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "8cf4cfdd-7d85-4af4-9e77-096c8a4cdacb"
-    },
-    {
-        "url": "https://marscode.paluai.com/doubao",
-        "title": "豆包MarsCode",
-        "description": "免费AI编程助手，DeepSeek满血版模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/28f3fd45-f176-4aa9-af0e-a68559b86f85.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "7eac2d73-ca6c-4cff-8806-aadc5380717b"
-    },
-    {
-        "url": "https://comate.baidu.com",
-        "title": "文心快码",
-        "description": "百度推出的AI编程助手，基于文心大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cee71c46-b7b1-48a2-a4a5-9eb35fcc4b68.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "190c0e7d-be03-4307-8d49-dddc8650e20c"
-    },
-    {
-        "url": "https://aws.amazon.com/codewhisperer/",
-        "title": "CodeWhisperer",
-        "description": "亚马逊推出的免费AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51540100-63ca-414f-ac7e-8a3b16f5f5c8.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "56d6efa3-c597-4a86-a53d-ef80bfa81d6b"
-    },
-    {
-        "url": "https://github.com/features/copilot",
-        "title": "GitHub Copilot",
-        "description": "GitHub推出的编程工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7890965-5e65-4aa9-8c08-fb17215d9b1f.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "d6f57600-976a-477f-ac06-9f2c34f9ad74"
-    },
-    {
-        "url": "https://www.doubao.com/chat/coding",
-        "title": "豆包AI编程",
-        "description": "豆包推出的AI编程新功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ec5cd1c0-715d-4875-8153-f969d5c87223.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "1b4528de-51ea-44ef-9882-4375b29c57e3"
-    },
-    {
-        "url": "https://firebase.studio",
-        "title": "Firebase Studio",
-        "description": "谷歌推出的编程工具，一站式开发全栈应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/771fd5e3-fd0f-4f06-8763-7f74c4bad61b.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "074b940d-0151-4794-892b-00c037d89cc1"
-    },
-    {
-        "url": "https://www.cursor.com",
-        "title": "Cursor",
-        "description": "AI代码编辑器，快速进行编程和软件开发",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cdd431c9-1872-4028-8afc-8435b05428fd.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "bd748a83-882a-4ed5-8e77-694354f06492"
-    },
-    {
-        "url": "https://windsurf.com/editor",
-        "title": "Windsurf",
-        "description": "Codeium公司推出的编程工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8faa6817-e1a4-403d-9a75-8b192e33668e.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "396f9d4f-e983-4878-9246-1deab0184f1b"
-    },
-    {
-        "url": "https://bolt.new",
-        "title": "Bolt.new",
-        "description": "StackBlitz 推出的全栈AI代码工具，可以看作 Artfacts、V0 和 Replit 的结合体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/613d2f51-8e7b-4f3e-964e-7d85606a480d.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "4eb4dd8a-a54e-461a-9a7d-41a626fc9851"
-    },
-    {
-        "url": "https://docs.replit.com/replitai/agent",
-        "title": "Replit Agent",
-        "description": "AI初创公司Replit推出的编程工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5148af9e-c97d-40b9-aa86-9063f8208dec.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "a338f6cf-51b9-4d52-b466-eb7ab5f21cc6"
-    },
-    {
-        "url": "https://lovable.dev",
-        "title": "Lovable",
-        "description": "编程工具，用自然对话快速构建网站和Web应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9700e225-86d1-4ead-a393-d70b38121e8d.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "97f2102b-4102-4329-9ee3-ae8626edf9b3"
-    },
-    {
-        "url": "https://www.jetbrains.com/junie",
-        "title": "Junie",
-        "description": "JetBrains 推出的 AI 编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/db807801-bdbb-4721-9b77-6f1a578098b3.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "c7986d9f-e3bc-4480-a861-45218557373a"
-    },
-    {
-        "url": "https://www.xiaohuanxiong.com/code",
-        "title": "代码小浣熊",
-        "description": "商汤科技推出的免费AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/00883842-bdc2-4d08-92a1-0bf3cb48d82c.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "eebea6cd-c2cd-477e-9939-b19770dafde9"
-    },
-    {
-        "url": "https://cloud.tencent.com/product/acc",
-        "title": "腾讯云AI代码助手",
-        "description": "腾讯推出的AI编程辅助工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3a58399d-f0eb-4580-915b-2f8d82ba6909.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "ba388f61-28cf-4f9c-bbe8-81418b3c7e56"
-    },
-    {
-        "url": "https://www.codeium.com/",
-        "title": "Codeium",
-        "description": "免费的编程工具，智能生成和补全代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7026304-8120-4105-a820-e170e1654549.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "ef3ec10b-ff8f-4bdd-a15c-6a52c313f98a"
-    },
-    {
-        "url": "https://codegeex.cn/",
-        "title": "CodeGeeX",
-        "description": "智谱AI推出的免费AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6a8036e-04e2-4e93-be81-5852a5e96f58.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "892fd25a-4cd1-4d22-a1a9-cb0433dca9dd"
-    },
-    {
-        "url": "https://mgx.dev",
-        "title": "MGX",
-        "description": "基于MetaGPT框架的编程工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16207d7e-88c5-42ca-b82c-22769f0c40f0.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "5c38584d-12b2-4380-8cb4-8336b28a3e81"
-    },
-    {
-        "url": "https://sourcegraph.com/cody",
-        "title": "Cody",
-        "description": "Sourcegraph推出的免费编程工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/15120e17-c1e3-4ded-a2d4-f89c81428065.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "b53a840e-07de-4172-903d-3ed11a41e068"
-    },
-    {
-        "url": "https://www.devchat.ai/zh",
-        "title": "DevChat",
-        "description": "开源的支持多款大模型的AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bf7c1e4e-ba6a-4a57-a750-f8841fdd4a28.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "plugin",
-        "id": "1b6a3b2a-995d-4212-8b0d-bb41c0668bf7"
-    },
-    {
-        "url": "https://www.codium.ai/",
-        "title": "CodiumAI",
-        "description": "免费的AI代码测试和分析工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25450e11-edfe-4f83-84b5-8c8eff3e0721.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "c075318f-43c0-4475-a141-0000dd7a183c"
-    },
-    {
-        "url": "https://cosine.sh/genie",
-        "title": "Genie",
-        "description": "Cosine AI推出的AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94146881-a658-4025-9d6d-f98fe1246c04.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "app",
-        "id": "b1e8deee-1c28-4382-9825-e62af9f90a0f"
-    },
-    {
-        "url": "https://www.codeflying.net",
-        "title": "码上飞",
-        "description": "AI软件开发平台，一句话自动生成端到端应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebeafbba-ba0c-41d4-89af-327601bf5873.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "8f589425-30a8-48ed-b030-4ee8e954d9dd"
-    },
-    {
-        "url": "https://iflycode.xfyun.cn",
-        "title": "iFlyCode",
-        "description": "科大讯飞推出的智能编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/115b920d-4db1-4c6e-9d2a-956a3b08a0ac.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "7b359680-edf2-4e8c-aec8-dca1fcafb6ed"
-    },
-    {
-        "url": "https://twinny.dev",
-        "title": "Twinny",
-        "description": "专为 VS Code 设计的AI代码补全插件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/482a2ed9-d4c6-4526-be4e-d465ec5abb37.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "cf8888e6-31f2-41a1-96e5-ec9613bfc2dd"
-    },
-    {
-        "url": "https://idx.dev",
-        "title": "Project IDX",
-        "description": "谷歌推出的AI云端开发和代码编辑器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/74f45092-9dab-4621-a558-e67898f78709.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "a3938327-e416-4604-bda4-3ef828987f49"
-    },
-    {
-        "url": "https://sketch2code.azurewebsites.net/",
-        "title": "Sketch2Code",
-        "description": "微软AI Lab推出的将手绘草图转换成HTML代码工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/44fd3be3-acdb-4566-b72b-269c11cd3694.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "99fdf338-8874-487d-b8aa-9cda39eca34c"
-    },
-    {
-        "url": "https://codefuse.alipay.com",
-        "title": "CodeFuse",
-        "description": "蚂蚁集团推出的AI代码编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2e9193c1-c7ce-4992-a01d-200a3abb0cf9.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "c1dfec13-188b-4872-9d62-f633c55c05c9"
-    },
-    {
-        "url": "https://tabby.tabbyml.com",
-        "title": "Tabby",
-        "description": "免费开源的自托管AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b3555bf1-2f4e-488e-820f-d6f411f73dbe.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "bfcbf4b5-d74f-41fa-81a9-1016c858045d"
-    },
-    {
-        "url": "https://so.csdn.net/chat",
-        "title": "C知道",
-        "description": "CSDN推出的AI技术问答工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff820821-0878-42ff-a43e-989d8c664c17.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "c369d40a-f555-4092-9c31-b0c9bd7fd484"
-    },
-    {
-        "url": "https://coderider.gitlab.cn",
-        "title": "驭码CodeRider",
-        "description": "极狐GitLab推出的AI编程与软件智能研发助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfda4d64-e6cc-42e9-8740-fa09a9d65c97.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "d0973412-2f73-475e-8247-dc9c2c370521"
-    },
-    {
-        "url": "https://about.gitlab.com/gitlab-duo",
-        "title": "Duo Chat",
-        "description": "GitLab推出的AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee82490e-7732-4a09-8c34-0db793fea039.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "26ae54b6-14f0-4c04-bcfa-7c5dbb1cf38b"
-    },
-    {
-        "url": "https://coderabbit.ai",
-        "title": "CodeRabbit",
-        "description": "AI驱动的代码审查平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff4b3bb1-4db0-4310-82c9-a4596ee9454a.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "a191f2e6-c6e9-4a5e-8af6-fa18fdd9df99"
-    },
-    {
-        "url": "https://www.augmentcode.com",
-        "title": "Augment Code",
-        "description": "AI编程辅助工具，专为大型代码库设计",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ee89e83-6020-497d-8c23-f3188235f5e6.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "d9cb4c3d-7c54-4975-98ad-008492a5b9e9"
-    },
-    {
-        "url": "https://preview.devin.ai",
-        "title": "Devin",
-        "description": "首个全自主的AI软件工程师智能体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84c8822a-d552-4076-b41d-ff5c55e56afa.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "10373bbd-e307-43a9-974c-16baf9dcb8d2"
-    },
-    {
-        "url": "https://plandex.ai",
-        "title": "Plandex",
-        "description": "免费开源的基于终端的AI编程引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/57c2b0e2-77ad-45e9-bbad-0e1c2b8dc028.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "7f372293-7131-4ef5-8396-cafb1ae44aea"
-    },
-    {
-        "url": "https://code.fittentech.com",
-        "title": "Fitten Code",
-        "description": "非十科技推出的免费AI代码助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd95c49b-64a6-4656-ae9f-439ccc5ee932.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "b8250077-ceee-4ae6-b10e-37330dcbb9f7"
-    },
-    {
-        "url": "https://www.useblackbox.io",
-        "title": "BLACKBOX AI",
-        "description": "黑箱AI编程助理，快速代码生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/75ceb4ef-2412-422d-85ad-7b22038c1354.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "f7f6aa1d-7cfc-43ec-bc53-c1a60f3b39b4"
-    },
-    {
-        "url": "https://soloist.ai",
-        "title": "Solo",
-        "description": "Mozilla推出的零编程无代码AI网站建设工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/425f3b0d-761e-4195-9c94-fd649037a9c2.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "4c3e0784-1dcf-4da0-bd41-4d4168eab58d"
-    },
-    {
-        "url": "https://www.jetbrains.com/ai",
-        "title": "JetBrains AI",
-        "description": "JetBrains推出的AI编程开发助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c26235c-672b-4af6-b209-7a22aae356b7.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "d4bf96d2-b95d-4716-af2d-49e2783b6369"
-    },
-    {
-        "url": "https://www.huaweicloud.com/product/codeartside/snap.html",
-        "title": "CodeArts Snap",
-        "description": "华为云推出的智能编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/45255887-9403-482b-b4f8-75d069bba302.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "551efb95-f82b-4f73-b237-78a046eace41"
-    },
-    {
-        "url": "https://www.askcodi.com/",
-        "title": "AskCodi",
-        "description": "你的个人AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/acc514d6-e282-461f-ae7d-f0f59f462882.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "1abc30e3-d130-4cb8-980d-ca1e6cc06fbe"
-    },
-    {
-        "url": "https://v0.dev",
-        "title": "v0.dev",
-        "description": "AI生成前端React/UI组件，由Vercel推出",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac8e35f5-84aa-4a57-8250-e86f501455d1.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "36acacb6-84b2-42f6-bdc6-f6783d716813"
-    },
-    {
-        "url": "https://codesandbox.io/blog/meet-boxy-ai-coding-assistant",
-        "title": "Boxy",
-        "description": "CodeSandbox推出的AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b68b3b8a-3bf5-4bd3-b68b-268b11eead4a.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "46cbc21d-244a-4e21-a202-7e5d0ed1a2b9"
-    },
-    {
-        "url": "https://www.quest.ai",
-        "title": "Quest AI",
-        "description": "AI将设计稿生成React代码，支持JavaScript和TypeScript",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8c1af342-af5e-4551-84b5-eb71d2bb49af.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "5cb3c841-450e-4a11-a32a-7d5f6dd8fb11"
-    },
-    {
-        "url": "https://sky-code.singularity-ai.com/index.html#/",
-        "title": "天工智码Skycode",
-        "description": "AI智能编程助手，轻松生成各种代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1aa9833e-7085-4523-972a-c3d1eb569c3d.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "4e82d30b-7064-4c34-b012-278e1a38d493"
-    },
-    {
-        "url": "https://jam.dev/jamgpt",
-        "title": "JamGPT",
-        "description": "AI Debug调试助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bdf3ea8e-03cb-4b3a-894a-f66095a1324f.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "9292a800-c814-4f9d-a3ab-01f8f6a63f7b"
-    },
-    {
-        "url": "https://www.aixcoder.com",
-        "title": "aiXcoder",
-        "description": "自然语言到代码的方法级代码生成，以及多行智能代码补全",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4703158-7bc4-44ff-a54e-ee9ffa50f5ca.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "28df4c78-5b94-45d9-82de-5b26d64fcc9c"
-    },
-    {
-        "url": "https://www.airops.com/",
-        "title": "AirOps",
-        "description": "AI SQL语句生成和修改",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edbd9f93-1c81-4298-a06c-0566cbf93e0d.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "429d57ae-3949-4b9d-83aa-d2385560298b"
-    },
-    {
-        "url": "https://www.imgcook.com/",
-        "title": "Imgcook",
-        "description": "阿里推出的免费设计稿智能生成前端代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/437a7d9a-0cf5-4f54-989e-aaaf365d17f2.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "96b1180c-e2c7-4890-8598-b82674a8801b"
-    },
-    {
-        "url": "https://ling-deco.jd.com/",
-        "title": "Deco",
-        "description": "京东推出的设计稿一键生成多端代码工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fbd2deb8-1a05-42b0-bf0c-a62afd26cd46.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "6ab82dc5-57ab-48a0-b38d-86841e0c4b11"
-    },
-    {
-        "url": "https://replit.com/site/ghostwriter",
-        "title": "Ghostwriter",
-        "description": "知名在线编程IDE Replit推出的AI编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/29068b5f-a268-4aa0-8ef3-fe23633d8fd2.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "ce77448e-d2fd-4ba3-99f7-c5c29492b4a6"
-    },
-    {
-        "url": "https://www.codiga.io/",
-        "title": "Codiga",
-        "description": "AI代码实时分析",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/369a7e85-7978-40a0-b168-e5a25e8ba78c.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "82c67f0c-de1f-4110-ac0b-f8e83293b77e"
-    },
-    {
-        "url": "https://www.locofy.ai/",
-        "title": "Locofy",
-        "description": "AI无代码工具将Figma、Adobe XD和Sketch设计转换成前端代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6cb6033-0379-4aec-9234-0e094d9d54a3.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "0400d965-93ff-46b7-92b0-cd089e2fc814"
-    },
-    {
-        "url": "https://fronty.com/",
-        "title": "Fronty",
-        "description": "AI智能将图片转换成HTML和CSS代码",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e098eb1a-9c06-443e-b466-d16d43256aae.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "d2bcf1f0-7279-4b6e-970b-fee37b98a20d"
-    },
-    {
-        "url": "https://www.marsx.dev/",
-        "title": "MarsX",
-        "description": "AI无代码软件开发",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c762c06f-9cec-4fb1-89e0-0381c13cd9df.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "3020404a-1517-412c-b430-b79afde0abfd"
-    },
-    {
-        "url": "https://www.tabnine.com/",
-        "title": "Tabnine",
-        "description": "AI代码自动补全编程助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/78595e7e-3032-4266-b4ca-a19245c554f0.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "f6001343-0d25-47c1-9c2e-33e923d62ad4"
-    },
-    {
-        "url": "https://mutable.ai/",
-        "title": "Mutable AI",
-        "description": "人工智能加速软件开发",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09c58371-8210-479b-b515-f525c3d9aae9.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "e607fbe3-23ee-437b-adc7-292ac6d25ee2"
-    },
-    {
-        "url": "https://debuild.app/",
-        "title": "Debuild",
-        "description": "低代码快速开发网页应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f3a7d51c-8d96-49f1-b0dd-7bfc54475caa.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "1d26a8a5-4375-453f-b247-027389fa1571"
-    },
-    {
-        "url": "https://www.warp.dev/",
-        "title": "Warp",
-        "description": "21世纪的终端工具（内置AI命令搜索）",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4d809132-3ff6-42e0-a4cb-2be8a541a377.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "63994934-d13e-4e45-a551-5d312e480738"
-    },
-    {
-        "url": "https://fig.io/",
-        "title": "Fig",
-        "description": "下一代命令行工具（内置AI终端命令自动补全）",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20e03366-537b-482c-8105-cf23087a4e0b.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "33c0e7db-b20b-4a6f-b7e8-aa5b1e06616e"
-    },
-    {
-        "url": "https://codesnippets.ai/",
-        "title": "CodeSnippets",
-        "description": "AI代码生成、补全、分析、重构和调试",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6a40963b-23c2-4c1b-877e-166d92224ee9.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "27846e6a-f0d2-495c-b4d8-335cc224f022"
-    },
-    {
-        "url": "https://hocoos.com/",
-        "title": "Hocoos",
-        "description": "无代码AI智能在线快速创建网站",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f708ec99-37be-4ff3-b608-be24096c0c5c.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "f259b580-113a-4dd9-ab07-a2a8a3ed6dd7"
-    },
-    {
-        "url": "https://httpie.io/ai",
-        "title": "HTTPie AI",
-        "description": "AI API开发工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/15f18c12-cfab-492f-8f1f-26d3cb2d4c0f.gif",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "6ee1430a-04a9-4ccd-8796-78013e9a3349"
-    },
-    {
-        "url": "https://ai-code-reviewer.com/",
-        "title": "AI Code Reviewer",
-        "description": "AI代码检查",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d2fb69f-a103-4edb-a626-e38a44190521.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "46a4cab4-33e9-4105-916e-bbc01b848246"
-    },
-    {
-        "url": "https://visualstudio.microsoft.com/zh-hans/services/intellicode/",
-        "title": "Visual Studio IntelliCode",
-        "description": "Visual Studio AI辅助开发",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43877041-7644-4724-b221-92a21cab3e56.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "003450ab-f143-4775-bfc8-237f6b07fe1a"
-    },
-    {
-        "url": "https://www.heycli.com/",
-        "title": "HeyCLI",
-        "description": "自然语言转义为CLI命令",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1a252933-efa3-424d-a398-c316cdbfd35f.png",
-        "category": [
-            "编程工具"
-        ],
-        "type": "web",
-        "id": "663cc20f-5118-4a55-ba23-9cb093c63aec"
-    },
-    {
-        "url": "https://www.promptingguide.ai/zh",
-        "title": "提示工程指南",
-        "description": "提示工程指南（Prompt Engine...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5a66705-f50b-4151-abd2-c7139dc39079.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "bfc10e55-4a1e-4b0c-ac70-07e1cc1dcb67"
-    },
-    {
-        "url": "https://promptperfect.jinaai.cn",
-        "title": "PromptPerfect",
-        "description": "PromptPerfect 是一款专业好...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c621588-9c2a-4f66-9fc0-b9a37bf1e4cd.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "99954922-faca-4fac-89d5-50d17462ee28"
-    },
-    {
-        "url": "https://flowgpt.com/",
-        "title": "FlowGPT",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c148e62-c1d5-4a93-9d6f-0dae82657a1c.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "8f718ce0-ae2b-47f3-bf6a-3582e6546d8d"
-    },
-    {
-        "url": "https://openart.ai/promptbook",
-        "title": "Stable Diffusion Prompt Book",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bbe09e8e-df67-4b8e-9e21-b79228f6263a.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "847f97b1-912d-46b4-a551-7bd1442a58bd"
-    },
-    {
-        "url": "https://prompthero.com/",
-        "title": "PromptHero",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef876c2c-98cf-4489-aa10-4f97d4a8737a.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "dc5db75a-9d51-4642-85d3-436775224278"
-    },
-    {
-        "url": "https://www.clickprompt.org/zh-CN/",
-        "title": "ClickPrompt",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51f613e6-46fc-4680-8625-5d020beb3984.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "1cc0b932-2a50-4e75-b29b-c503216a9ea9"
-    },
-    {
-        "url": "https://www.aipromptgenerator.net/zh",
-        "title": "AI Prompt Generator",
-        "description": "AI Prompt Generator是什么 A...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/19fecdbf-806f-4ae5-b50f-18d1c5681ee1.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "59b48314-1a80-47ab-adb4-10c5401e6fa4"
-    },
-    {
-        "url": "https://www.aishort.top/",
-        "title": "AI Short",
-        "description": "AI Short是什么 AI Short是一...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef7d9bbf-522b-4408-b9be-2f6243158f30.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "bac26f0c-2f8e-482b-baaf-01c75eac7c30"
-    },
-    {
-        "url": "https://github.com/langgptai/LangGPT",
-        "title": "LangGPT",
-        "description": "LangGPT是什么 LangGPT是一种...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7849766d-ea76-4231-90ba-1211b62fa6ca.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "08a77423-ff32-4b37-8b9c-2db027eb3246"
-    },
-    {
-        "url": "https://generrated.com/",
-        "title": "Generrated",
-        "description": "当你第一次开始使用DALL•E 2...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3d9bc78c-69f7-4b83-8810-de888a8ae551.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "9f226c4d-5c13-4d4f-b52f-bd6de2f9204b"
-    },
-    {
-        "url": "https://publicprompts.art/",
-        "title": "PublicPrompts",
-        "description": "PublicPrompts是什么 PublicP...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/208bda49-5a09-4512-9f67-20864c33e9b0.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "de565b02-1344-4a10-acbf-ccc709af9a89"
-    },
-    {
-        "url": "https://snackprompt.com/",
-        "title": "Snack Prompt",
-        "description": "输入正确的提示词，可以让Cha...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5871bbd9-1189-4268-a878-b8bccf5ad4a3.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "047a9177-071a-4078-a62c-e83aacd105f2"
-    },
-    {
-        "url": "https://www.aiprm.com/",
-        "title": "AIPRM",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a4f8a112-d003-4e55-952a-3da702124520.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "516d121e-102a-466d-a0f5-ba302756ab7c"
-    },
-    {
-        "url": "https://www.ai016.com/",
-        "title": "绘AI",
-        "description": "绘AI致力于探索和创造一种全...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/987fcf60-7aa4-4101-bfa9-55296d40c57e.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "012f0d70-c1d3-4798-b8de-421866cc9cdc"
-    },
-    {
-        "url": "https://prompt.noonshot.com/",
-        "title": "MJ Prompt Tool",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/130a5cc0-112f-4bf7-9aa1-92b9c9548cfe.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "c162425f-6bb7-4c13-b707-9e9366b8e897"
-    },
-    {
-        "url": "https://tools.saxifrage.xyz/prompt",
-        "title": "Visual Prompt Builder",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4fec661-d06a-468b-a566-0dad1b88c73a.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "505bad89-6175-4ccd-9ca2-c51fbfccf493"
-    },
-    {
-        "url": "https://github.com/benf2004/ChatGPT-Prompt-Genius",
-        "title": "ChatGPT Prompt Genius",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d826544b-360f-44dc-b03a-8dd327f3038d.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "eefc6d37-e358-4030-8204-3e982ce04c87"
-    },
-    {
-        "url": "https://promptbase.com",
-        "title": "PromptBase",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4c3bf232-d1e3-4f03-a661-639c9f349d87.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "3bc7ac0a-3531-4953-80ab-6f4daf18b8e1"
-    },
-    {
-        "url": "https://promptvine.com/",
-        "title": "PromptVine",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8d9b5e65-fbdc-40c3-ab4e-b85bf82f447b.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "85dd1cf3-97db-4bcb-a361-0327fcbb09f5"
-    },
-    {
-        "url": "https://prompts.chat/",
-        "title": "Awesome ChatGPT Prompts",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b669210-5770-48f2-adbc-9d9d46aac294.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "1ef445f9-8719-4cde-8d08-9c45c2407488"
-    },
-    {
-        "url": "https://learningprompt.wiki/",
-        "title": "Learning Prompt",
-        "description": "",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3fd7f440-73ad-4bfe-a2e4-f430afec5152.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "c2a09ca3-aacf-42c4-8991-14e0e6c18072"
-    },
-    {
-        "url": "https://www.aishort.top/",
-        "title": "ChatGPT Shortcut",
-        "description": "ChatGPT Shortcut是国内开发...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/04f64d60-c5a3-4fdd-8a9f-88c0fd7b4360.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "206fe2c5-c207-4b2d-8482-dc78ed081998"
-    },
-    {
-        "url": "https://icihun.com",
-        "title": "词魂",
-        "description": "词魂是一个AIGC精品提示词库...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c532a025-6d1b-401e-b3dd-b72db748d22d.png",
-        "category": [
-            "提示词工程"
-        ],
-        "type": "web",
-        "id": "7eab4efb-3363-47b3-ba54-b2aedf43070d"
-    },
-    {
-        "url": "https://www.chineselaw.com/tyjs/index",
-        "title": "元典智库",
-        "description": "智能法律知识服务平台和搜索引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d2a2480b-3dca-47c6-a927-690c49188b0e.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "4cfc9f94-0dbf-4e53-883d-8595b67e83f7"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/farui",
-        "title": "通义法睿",
-        "description": "阿里推出的免费AI法律顾问助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bf7a0785-7d3d-4c65-9720-7dfaab0bbc4a.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "7baa0f73-efa0-4018-a6e0-1b0e37cd32ac"
-    },
-    {
-        "url": "https://ailegal.baidu.com/",
-        "title": "法行宝",
-        "description": "百度推出的免费AI法律助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4b5f539-0a6a-4177-aade-7126e819a716.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "3d03db02-075b-40b1-9427-a92d2c428490"
-    },
-    {
-        "url": "https://chatlaw.cloud/lawchat/",
-        "title": "ChatLaw",
-        "description": "北大开源的法律大模型和助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/72e3dfb6-1bc4-460f-93f9-9fe549920347.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "e6e93d4a-6f65-49df-9def-eebf7fec4e26"
-    },
-    {
-        "url": "https://www.delilegal.com/search",
-        "title": "得理法搜",
-        "description": "AI法律智能检索系统",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dc079f8a-6c37-470e-86c5-1cd33d43293c.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "df2bba37-7efe-44e8-9afe-45252e56c708"
-    },
-    {
-        "url": "https://www.fazhi.law",
-        "title": "法智",
-        "description": "同花顺推出的AI法律助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6e1a1f1-7705-4a64-be8b-ebeecce0a8bb.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "c92dbd78-056a-4041-a1ec-774a49f7b8f0"
-    },
-    {
-        "url": "https://www.hairuilegal.com",
-        "title": "海瑞智法",
-        "description": "一站式AI法律咨询助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bc50cc9-5293-4a3c-85c6-63bfd03c45ac.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "9ee641af-3149-4780-aacd-d549048fa648"
-    },
-    {
-        "url": "https://contract.yoo-ai.com",
-        "title": "合同嗖嗖",
-        "description": "专业的AI法律合同生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6977cdb-b12c-4849-aa86-600dc870c19e.png",
-        "category": [
-            "法律助手"
-        ],
-        "type": "web",
-        "id": "2440f4eb-ca0d-4263-a5d4-5b3dd20d565f"
-    },
-    {
-        "url": "https://tusiart.com",
-        "title": "吐司AI",
-        "description": "AI绘画模型社区和在线生图平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81e13040-90df-46ba-8623-048843cd7369.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "a1ebb334-0564-4832-9b9c-8e79dff0a3da"
-    },
-    {
-        "url": "https://www.meijian.com/mj-box/ai-pic-matting-intro",
-        "title": "美间AI抠图",
-        "description": "美间AI推出的免费智能抠图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/369fee83-d774-4349-9931-46e9a9ea8dd3.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2e86d99f-b1d9-439e-bc52-a2bf9476347d"
-    },
-    {
-        "url": "https://jimeng.jianying.com/ai-tool/home",
-        "title": "即梦",
-        "description": "抖音旗下免费AI图片创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/198938d4-35e3-4847-ab1e-915d889f3764.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "74a58f79-749f-4f54-a00b-c797eabbf8df"
-    },
-    {
-        "url": "https://abeiai.com",
-        "title": "阿贝智能",
-        "description": "一站式AI绘本创作平台，副业变现必备",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16aab08c-f473-41e5-9ba9-01a8904baf49.jpg",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "9d1ffb0d-b27c-48c0-8265-bc844e8742ea"
-    },
-    {
-        "url": "https://www.midjourney.com/home",
-        "title": "Midjourney",
-        "description": "AI图像和插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9b60cca-2928-4142-9edb-c6527c226925.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "75fa4b9b-e2aa-49c8-869e-25c526088e47"
-    },
-    {
-        "url": "https://artistrylab.net",
-        "title": "炉米Lumi",
-        "description": "字节跳动推出的AIGC图像创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e103d39d-cf3e-46b5-8604-365451fbc5cb.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "677356f8-4195-4a0a-a939-493fb21a9f9a"
-    },
-    {
-        "url": "https://civitai.com/",
-        "title": "Civitai",
-        "description": "免费的AI图像绘画作品和模型分享平台和社区",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c5832324-5e91-4853-a545-14c3e0b456d8.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "18e84982-edde-4cb2-a0fb-452b8ea6c8a2"
-    },
-    {
-        "url": "https://d.design",
-        "title": "堆友AI反应堆",
-        "description": "阿里旗下堆友推出的多风格AI绘画生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/deab4051-0ca4-44e9-bbee-075177c74127.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2f760fa9-0a6e-4223-a79d-017b96c8a64a"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/wanxiang",
-        "title": "通义万相",
-        "description": "阿里最新推出的AI绘画创作模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/101e3689-82b7-495e-bdb7-3517874c30c1.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "6d970382-9e6d-4e2b-94c2-a059cde1b796"
-    },
-    {
-        "url": "https://miaohua.sensetime.com/inspiration",
-        "title": "秒画",
-        "description": "商汤科技推出的免费AI作画和图片生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21d29027-e561-451d-9b30-38b4869c4218.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "1efa15a7-dbdd-4023-9ac7-57e054527402"
-    },
-    {
-        "url": "https://www.whee.com/",
-        "title": "WHEE",
-        "description": "美图推出的AI图片和绘画创作生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fdc93d6f-7af6-4585-8b96-17e0f5b1dd36.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "b77d20bd-dabb-4fe3-bf9b-238f6201e752"
-    },
-    {
-        "url": "https://www.liblib.art",
-        "title": "LiblibAI·哩布哩布AI",
-        "description": "国内领先的AI图像创作平台和模型分享社区",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0cb06aed-3b9e-4b51-a265-df6b2f2616e8.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "d8443898-711f-4d97-902d-8619c86acc80"
-    },
-    {
-        "url": "https://design.meitu.com/aigc/text-to-image",
-        "title": "美图AI文生图",
-        "description": "美图推出的AI文本生成图片的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d0c0493-78f3-4d8a-a0c8-d3925c8aae63.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "083d2679-3b39-4a47-9eb3-9d792cb2226b"
-    },
-    {
-        "url": "https://www.qiyuai.net",
-        "title": "奇域AI",
-        "description": "中式审美国风AI绘画创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/603997f0-fb8d-4534-9465-bb3ca696f822.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "6feb04d5-1b3d-4fd4-888f-bf8698e067e6"
-    },
-    {
-        "url": "https://klingai.kuaishou.com",
-        "title": "可灵AI",
-        "description": "快手推出的AI图像和视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c372fb3a-b500-4dea-b36f-4759a55a2af9.png",
-        "category": [
-            "图像工具",
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "b99c47cc-fffa-4b9f-bdee-b4bad5be7917"
-    },
-    {
-        "url": "https://img.logosc.cn",
-        "title": "AI改图神器",
-        "description": "AI万能图片在线编辑器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d4318c88-7e73-432d-8fea-748f93c38cd2.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "b11d8106-3bf3-4624-a6a2-6e822b553233"
-    },
-    {
-        "url": "https://www.krea.ai",
-        "title": "Krea AI",
-        "description": "实时AI图像、视频生成和编辑平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/68f29c6e-dd38-4cfa-895a-65244d021463.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "afbcb903-e083-400b-998b-dbf7adadc0ce"
-    },
-    {
-        "url": "https://www.photoroom.com/zh",
-        "title": "Photoroom",
-        "description": "在线AI图片编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb98ebb9-8362-4e92-8973-0e41e17220e0.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "5da2f82d-5212-4033-bdab-0af6ea2457f3"
-    },
-    {
-        "url": "https://ribbet.ai/",
-        "title": "Ribbet.ai",
-        "description": "免费的多功能AI图片处理工具箱",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c615d791-d360-45fc-bec3-828e57636bd0.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "2b8cdfd8-7638-41e0-921d-5dc65a9ac507"
-    },
-    {
-        "url": "https://agi.taobao.com",
-        "title": "万相营造",
-        "description": "阿里旗下推出的多模态AI创意生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e92779dc-4728-4003-aaaf-334d0a9499e9.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "01a98341-048b-4fd2-affe-ceb428a118c9"
-    },
-    {
-        "url": "https://www.photosir.com",
-        "title": "悟空图像PhotoSir",
-        "description": "新一代专业图像处理软件，更智能、更高效、更好用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/752a7abc-5b96-49b8-8a07-e8b6bdd6d3d3.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "987e2eb9-5d7c-4b3b-93ae-3aa5eb8f7d26"
-    },
-    {
-        "url": "https://chacha.so.com/home",
-        "title": "360智图",
-        "description": "360推出的AI作图平台，支持智能抠图、智能消除、智能放大、智能配图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/821332b2-7eb5-472d-92b0-92ab84509b6f.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "ee9aaef9-fabb-4b60-abd7-85205aa9fda8"
-    },
-    {
-        "url": "https://www.pixcakeai.com",
-        "title": "像素蛋糕",
-        "description": "像甜科技推出的AI图像后期软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/73d0dac0-8b01-473b-ab49-54885a501c3f.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "bdb41c97-7ff5-4a9e-951f-a1b26178decd"
-    },
-    {
-        "url": "https://www.remove.bg/zh",
-        "title": "remove.bg",
-        "description": "强大的AI图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3e54dff-f24e-43cd-88d3-922672ce2858.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "5944122a-3ed3-4615-a815-ce2a9cf094b8"
-    },
-    {
-        "url": "https://ifshot.com",
-        "title": "如果相机",
-        "description": "仅需1张照片，快速生成AI写真照片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89475663-cb48-4bc0-aca8-c58970f52dbf.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "8a1f2a9c-0fc5-4d32-b787-f917ac016354"
-    },
-    {
-        "url": "https://arc.tencent.com/zh/ai-demos/",
-        "title": "ARC",
-        "description": "腾讯旗下ARC实验室推出的免费AI图片处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/531b38d4-fab1-4ba9-bba7-37e8a19a1890.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "407e1b2f-501f-448a-96fe-3734dfc18bae"
-    },
-    {
-        "url": "https://www.cutout.pro/",
-        "title": "Cutout.Pro",
-        "description": "AI在线处理图片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d6247e6f-13bb-4b0a-96a4-b50bc6811872.png",
-        "category": [
-            "图像工具",
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "fb4d2889-9322-4153-9e6b-175d57bc7656"
-    },
-    {
-        "url": "https://magicstudio.com/zh",
-        "title": "MagicStudio",
-        "description": "高颜值AI图像处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ed484c65-dc8d-4621-8dde-a26752426416.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "866c1425-1735-408d-a82f-571391a090b3"
-    },
-    {
-        "url": "https://booltool.boolv.tech/home",
-        "title": "Booltool",
-        "description": "在线AI图像工具箱",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81512f9a-18cb-4653-90d9-7d9a03903434.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "f91ca075-59bf-4f52-a702-e262800c7ed4"
-    },
-    {
-        "url": "https://faceswapper.ai",
-        "title": "Faceswapper",
-        "description": "AI在线换脸工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89470c97-7544-4e4a-9b58-090a355eef1f.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "31ab004d-d758-49ec-a0db-264cf61be5d5"
-    },
-    {
-        "url": "https://clipdrop.co/",
-        "title": "ClipDrop",
-        "description": "Stability.ai推出的AI图片处理系列工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d6f6683-0f07-4045-94a7-2ffebe5df505.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "36eae13c-d151-47dc-b2a6-f47f9960ee5c"
-    },
-    {
-        "url": "https://vmake.ai",
-        "title": "Vmake AI",
-        "description": "AI在线图像和视频编辑平台，专为电商、设计提供服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/530fc329-ab4d-464f-96c3-f41b23616ff1.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "e27d4c5f-e540-4877-bdc0-539cccf1a71c"
-    },
-    {
-        "url": "https://app.leonardo.ai/auth/login",
-        "title": "Leonardo.ai",
-        "description": "免费的AI绘画和图像生成工具和社区",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94e7f68b-f1de-4cef-a8e5-37b3067f80b3.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "6abb3fcf-5dcc-4396-9516-8056e18013e7"
-    },
-    {
-        "url": "https://www.deepswapper.com",
-        "title": "DeepSwapper",
-        "description": "免费的在线AI换脸工具，支持图片、视频多种格式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/101a8b0b-5e13-48bc-b89d-7e335e105d28.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "69bd59c9-f5d8-4d8e-9a1e-9dd192af872c"
-    },
-    {
-        "url": "https://www.kacha.ai/zh",
-        "title": "Kacha AI",
-        "description": "专业的AI写真工具，媲美专业摄影",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43449d3f-45ca-43a3-bd2b-afc590a9137b.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "1dd3915e-1a87-4879-83b9-510bb597e2de"
-    },
-    {
-        "url": "https://www.pictech.cc",
-        "title": "PicTech AI",
-        "description": "免费的在线图片翻译工具，支持一键抠图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dbd43314-f6bd-4ecb-a386-c3fbc605fd29.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "93afe91c-160d-439f-8e8c-878bebb083e0"
-    },
-    {
-        "url": "https://hotpot.ai",
-        "title": "Hotpot.ai",
-        "description": "AI图片图像处理和生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9baee105-3eb4-47d9-b18b-852eb6b9b283.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "a3e1435c-ecc8-4fe3-ab85-ff78ff400eb7"
-    },
-    {
-        "url": "https://www.icongen.io",
-        "title": "IconGen",
-        "description": "免费的icon图标AI生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25e9e922-6a44-4ecd-b9fa-3300a1818b18.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "894af4ff-8f07-4bd6-81fd-e655d90aae35"
-    },
-    {
-        "url": "https://paint.mobvoi.com",
-        "title": "言之画",
-        "description": "AI图像内容创作平台，由出门问问推出",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7eed531-3370-4a9d-afa3-051a024c833e.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "f9235eaa-a18f-422c-84b4-4fa967808fdf"
-    },
-    {
-        "url": "https://yinian.cloud.baidu.com/creativity/main/workbench",
-        "title": "百度智能云一念",
-        "description": "基于百度文心大模型的多模态内容创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e9e2bd08-79da-4411-b7d1-3afda24db1e2.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "cd7181a9-df1c-4db4-bb31-104a5b770338"
-    },
-    {
-        "url": "https://www.aiyou.art",
-        "title": "艾绘",
-        "description": "一键创作故事、绘画、配音，轻松创建高质量的绘本故事",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e218c8c1-0d8f-4731-b1f5-e2b39b5b667e.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "0216356f-4727-4e8a-9909-b9541eb1ef1c"
-    },
-    {
-        "url": "https://www.diffus.graviti.com",
-        "title": "Graviti Diffus",
-        "description": "开箱即用的 Stable Diffusion WebUI 在线图像生成服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cd334579-93f9-4f7c-89ca-437b1805e804.png",
-        "category": [
-            "图像工具"
-        ],
-        "type": "web",
-        "id": "7d19ea08-022a-437f-aee6-a66e4626195c"
-    },
-    {
-        "url": "https://acgnai.art",
-        "title": "触手AI绘画",
-        "description": "免费专业的AI绘画/模型/分享平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89373daf-f46b-4844-9b49-025de2d594cf.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "87dcbf22-3cb7-4241-8e16-f9b701305657"
-    },
-    {
-        "url": "https://yige.baidu.com/",
-        "title": "文心一格",
-        "description": "AI艺术和创意辅助平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5cb951c2-5709-46b8-bd42-ba2a9d3afc3d.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "e12d0de5-2f77-4752-9f8d-a957fc80e414"
-    },
-    {
-        "url": "https://zmrj.art",
-        "title": "造梦日记",
-        "description": "AI一下，妙笔生画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cc7657df-023f-4519-9de0-34de9e7863e0.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2bbec84d-429d-4017-943f-27f89006a3c6"
-    },
-    {
-        "url": "https://www.canva.com/ai-assistant/",
-        "title": "Canva AI图像生成",
-        "description": "在线设计工具Canva推出的AI图像生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/56f60e90-60e3-40dd-8caa-cc05f9ad0055.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "c8435fdc-d73e-40a8-b804-0c6d9d8ab14c"
-    },
-    {
-        "url": "https://photo.baidu.com/photasy/home",
-        "title": "超能画布",
-        "description": "百度网盘推出的AI创意图像写真创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2106e45f-925a-4844-98fc-495e564ca2b7.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "77770542-92c4-44e0-a1c1-3bdfa65d74d1"
-    },
-    {
-        "url": "https://www.adobe.com/products/firefly.html",
-        "title": "Adobe Firefly",
-        "description": "Adobe最新推出的AI图片生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/918d9acf-5103-4522-9e89-d6030015f224.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "fb0b42b6-02ad-4595-9023-af2c2abcc5fb"
-    },
-    {
-        "url": "https://ai.sohu.com/search",
-        "title": "简单AI",
-        "description": "搜狐最新推出的AI图片生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fd1784ac-19cc-45c5-ba6e-2d28c7b7063a.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "7c423ffd-2102-45d2-8f02-46a265acf4c6"
-    },
-    {
-        "url": "https://maliang.mthreads.com",
-        "title": "摩笔马良",
-        "description": "摩尔线程推出的AI图像绘画创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f2b5a3bd-4d37-4c97-9f8e-86d6e413982b.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "213f3d80-1329-417c-aa36-9e6d3ef26568"
-    },
-    {
-        "url": "https://exactly.ai",
-        "title": "Exactly.ai",
-        "description": "专业的AI绘画和艺术创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edc091e6-f5d0-4958-9a07-337263a72009.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "45865501-6729-4e4e-9523-bec9d1ad00e8"
-    },
-    {
-        "url": "https://creator.nolibox.com",
-        "title": "画宇宙",
-        "description": "人工智能AI作画网站",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5a9b8feb-9455-4a09-8d83-0d82907074e3.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "f4eb4cb7-d107-4753-ae6c-051319b3cb2c"
-    },
-    {
-        "url": "https://6pen.art",
-        "title": "6pen Art",
-        "description": "面包多团队推出的从文本描述生成绘画艺术作品",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/beb9b5e1-bee9-43d3-9772-949d850b3564.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "7b363d92-88ee-4064-b86d-21807e923e91"
-    },
-    {
-        "url": "https://aiart.chuangkit.com/landingpage",
-        "title": "创客贴AI画匠",
-        "description": "创客贴推出的AI艺术画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6b6e146-13d5-40f2-8772-702d57af21b8.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "aa6f6fd7-29f9-40f4-864d-aa7c4920e2b6"
-    },
-    {
-        "url": "https://visualelectric.com/",
-        "title": "Visual Electric",
-        "description": "专业的高质量AI图像创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da34d3d7-ae3f-44fe-a6a2-58b060955424.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "68e022dc-34d3-40b3-9062-28e55c0e4840"
-    },
-    {
-        "url": "https://aigc.360.com",
-        "title": "360智绘",
-        "description": "360推出的AI图片和绘画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ea74e78-6df2-4e59-83df-2fad1f1a71fd.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "f3a1b65b-6b23-4f5b-9005-ebb91eb695e0"
-    },
-    {
-        "url": "https://ke.study.163.com/artWorks/painting",
-        "title": "网易AI创意工坊",
-        "description": "网易云课堂推出的AI作画平台，在线使用Stable Diffusion出图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/056ba9ac-a8aa-438f-92ca-294962b4adfc.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "9fb5d3a8-dd54-4252-88ac-137157d91273"
-    },
-    {
-        "url": "https://www.meta.com/ja-jp/help/artificial-intelligence",
-        "title": "Imagine with Meta",
-        "description": "Meta最新推出的在线AI图像生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2db41fd8-efe9-4698-81a5-68ac4c3d0e11.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "28a5537f-3dad-49e4-982c-6c008cb80b36"
-    },
-    {
-        "url": "https://www.freepik.com/ai/image-generator",
-        "title": "Freepik AI Image Generator",
-        "description": "Freepik最新推出的AI图片生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7fc0085e-b462-446c-ae1c-f682b72fd399.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "7885055a-6564-402b-b87d-3f1b1132cff7"
-    },
-    {
-        "url": "https://stockimg.ai/",
-        "title": "Stockimg AI",
-        "description": "AI生成各种类型的图像和插画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f118a473-f74b-4fac-bba3-8975e8f4c8e1.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2e2eb223-5bd7-42c9-91a5-a12d346cd7c0"
-    },
-    {
-        "url": "https://clipdrop.co/stable-doodle",
-        "title": "Stable Doodle",
-        "description": "StabilityAI最新推出的将手绘草图转换成精美图像的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e84e43f-666e-4c6e-a98f-7045b18bae1b.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "3bccba87-822a-47bf-835e-c600bb9dfde8"
-    },
-    {
-        "url": "https://175.fun",
-        "title": "175FUN",
-        "description": "免费AI绘画社区，国货之光",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7f20259e-afff-4b39-b7e9-b02376586889.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "991ef037-6b3f-4d5d-add6-c20afdf180d7"
-    },
-    {
-        "url": "https://xingzheai.cn/#create",
-        "title": "行者AI美术",
-        "description": "AI图片生成和美术创作工具箱",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f9dcbf8-fbdf-4207-b739-3f78da0a4876.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "e6638898-4b27-4082-8bb8-ed983c268f3e"
-    },
-    {
-        "url": "https://skybox.blockadelabs.com",
-        "title": "Skybox AI",
-        "description": "AI生成和合成360°全景图像插画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8f06286-38aa-45cd-8db9-141958a3db38.png",
-        "category": [
-            "图像工具",
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "fb04d0c1-6e1f-4d7a-8d5c-06ab8f122f6f"
-    },
-    {
-        "url": "https://facet.ai/",
-        "title": "Facet",
-        "description": "AI图片修图和优化工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c70c4343-a11c-4e19-ad16-7f1648b2e0e1.png",
-        "category": [
-            "图像工具",
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "e48c123e-1c04-4d3e-81bc-870e082c386e"
-    },
-    {
-        "url": "https://clipdrop.co/relight",
-        "title": "Relight",
-        "description": "ClipDrop推出的AI图像打光工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c0d35cc5-b04b-49af-8714-b179cc7d9b7e.png",
-        "category": [
-            "图像工具",
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "36b61e9c-8983-41d6-92d9-c773130bcd0f"
-    },
-    {
-        "url": "https://www.upscayl.org/",
-        "title": "Upscayl",
-        "description": "免费开源的AI图片无损放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/afd4f758-5a55-4e45-a28f-f9e06d6b9045.png",
-        "category": [
-            "图像工具",
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "7fff6d21-8395-475b-b63b-cd6ff412d8c7"
-    },
-    {
-        "url": "https://qianlu.cc",
-        "title": "千鹿AI",
-        "description": "AI设计助手，每日可免费生成300张图像",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ceade445-ac5d-4dc0-88c7-e6fa3e3b4489.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2fb60490-4e47-4c59-b2b6-1dcd639e8df5"
-    },
-    {
-        "url": "https://www.xingliu.art",
-        "title": "星流AI",
-        "description": "LiblibAI推出的一站式AI图像生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/02a07503-79e9-4efe-aba3-b9d34bf4d4b8.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "5ffc7782-309f-41be-b361-8750275a6713"
-    },
-    {
-        "url": "https://www.youchuan.cn",
-        "title": "悠船",
-        "description": "Midjourney官方推出的中文版AI图像生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38bd79d4-402a-42a2-9323-591e001c8350.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "d698ec8d-ca26-4c14-aa4d-7e96ee7ea06a"
-    },
-    {
-        "url": "https://www.ishencai.com",
-        "title": "神采",
-        "description": "让创意照进现实， AI生成创意插画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/804e0329-6a84-493c-9eea-748c45c16a0c.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "6add0f0e-ed46-47be-8856-44ef6826d456"
-    },
-    {
-        "url": "https://sky-paint.singularity-ai.com/index.html#/",
-        "title": "天工巧绘SkyPaint",
-        "description": "免费的AI插画绘制工具，由昆仑万维与奇点智源合作推出",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fcf4dc04-2ca2-4f78-9c98-6be6c73c64ae.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "db912bfd-e003-4c11-bc5d-09ee5affcccf"
-    },
-    {
-        "url": "https://flagstudio.baai.ac.cn/",
-        "title": "FlagStudio",
-        "description": "智源研究院推出的AI文本图像绘画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/73eb6459-b52f-49ba-b342-19883198acce.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "18092ebd-b2f4-4bf7-9329-9796f0912f34"
-    },
-    {
-        "url": "https://nightcafe.studio/collections",
-        "title": "NightCafe",
-        "description": "AI艺术插画在线生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2a6eaf5d-8b17-4bec-9f12-1e5f701a7103.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "3dcd7383-4192-44b5-a1ab-040ae201e4cd"
-    },
-    {
-        "url": "https://nijijourney.com",
-        "title": "niji・journey",
-        "description": "魔法般的二次元绘画生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9b79a9b1-e19e-4096-9621-b4fc5815df74.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "80ff96bf-c965-4d91-b9e2-429051e1447f"
-    },
-    {
-        "url": "https://deepdreamgenerator.com/",
-        "title": "Deep Dream Generator",
-        "description": "AI创建生成梦幻般的插画图片，刻画你的梦中场景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/647e0020-7c3d-4f9b-9ad7-e83b8213e2ab.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "7e17eca7-391c-4dfb-989a-fb8b9dee6aa4"
-    },
-    {
-        "url": "https://588ku.com/ai/wuxianhua/Home",
-        "title": "无限画",
-        "description": "千库网推出的AI图片插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84b273bb-5ca3-4f27-a394-64cc9d64fbb6.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "36de2987-cf80-4c84-bfee-53fa9c91c0a0"
-    },
-    {
-        "url": "https://www.bluewillow.ai/",
-        "title": "BlueWillow",
-        "description": "免费的AI图像艺术画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/11657a45-3218-42c0-867f-9a19794cf8c3.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "9686e644-e1f0-4ce2-9954-914f5a2c7b9f"
-    },
-    {
-        "url": "https://waifulabs.com/",
-        "title": "Waifu Labs",
-        "description": "免费在线AI生成二次元动漫头像",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/58510acb-878b-4512-8b24-1db6f3cd05a3.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "1c610a3b-9c11-4df5-b906-9c902fdb2ba7"
-    },
-    {
-        "url": "https://dreamlike.art/",
-        "title": "dreamlike.art",
-        "description": "免费在线插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bbf9d84a-2ddb-4ba9-944c-b7ea5dca06c4.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "ff48dd42-c553-402e-ab24-0b9f92c21880"
-    },
-    {
-        "url": "https://www.artbreeder.com/",
-        "title": "Artbreeder",
-        "description": "创建令人惊叹的插画和艺术",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/41c377f0-6bf7-4a77-8337-38ec6de8082d.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "b1a92c3a-80bf-4f8f-99ff-f290f7545318"
-    },
-    {
-        "url": "https://www.tiamat.world",
-        "title": "Tiamat",
-        "description": "国内团队推出的AI艺术画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0a6f505-850b-4dc0-a560-e6747ff5809b.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "75fd3b29-03ac-49b6-96ec-c38c7befc5da"
-    },
-    {
-        "url": "https://vegaai.net/",
-        "title": "Vega AI",
-        "description": "在线免费AI插画创作平台，支持文生图，图生图，条件生图等多种绘画模式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be723419-719c-42ef-8fdf-da94e0cb7070.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "f8707c39-fd08-434a-9f4d-2041ef69f1a1"
-    },
-    {
-        "url": "https://deepgram.com/ai-apps/craiyon",
-        "title": "Craiyon",
-        "description": "免费在线文本到图像生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/591c3fc0-f19e-4206-9b88-ecdb0fa5ce54.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "4814935c-8064-4623-b2a4-b62363f0856d"
-    },
-    {
-        "url": "https://aigc.wondershare.cn/",
-        "title": "万兴爱画",
-        "description": "万兴科技推出的AI生成高品质艺术画工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/132d439d-5bdf-4c14-aa77-e3a03fa1da7d.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "588fbcc7-a356-4106-b4e2-fd5a98a643c6"
-    },
-    {
-        "url": "https://photosonic.pro/",
-        "title": "Photosonic",
-        "description": "Writesonic推出的AI艺术插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a1d09db-f334-4793-ab3b-eb6827cd3b2e.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "1796f9ae-76d5-4fec-8d42-8a2b55b57031"
-    },
-    {
-        "url": "https://astria.us.com/",
-        "title": "Astria",
-        "description": "可定制的人工智能图像生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ef3796a-21f6-4453-8e73-d5f2966e299f.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2f6d6989-6ed6-4982-b05d-ccac6918829e"
-    },
-    {
-        "url": "https://getimg.ai/",
-        "title": "getimg.ai",
-        "description": "在线AI图像和插画创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/029d4c77-f0f6-48ce-ac0e-a4001a837132.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "fe0e5ca6-ab67-42c5-a376-b31e41ec564d"
-    },
-    {
-        "url": "https://www.dreamup.com",
-        "title": "DreamUp",
-        "description": "DeviantArt推出的AI插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/725be852-b91c-42db-9350-3d1e6aa36bf2.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "c20497f2-2439-4377-9d8b-45cd6012e3eb"
-    },
-    {
-        "url": "https://scribblediffusion.net/",
-        "title": "Scribble Diffusion",
-        "description": "将草图转变为精美的插画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6b23c0c1-f64c-4d0d-a725-25abdffe6eff.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "da28968e-8be1-4bf9-9656-638ea96b2cac"
-    },
-    {
-        "url": "https://lexica.art/",
-        "title": "Lexica",
-        "description": "基于Stable Diffusion的在线插画生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b42ec681-1bf9-4c21-bda7-7cd1942b6b4e.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "38549360-9fb5-4604-b613-deebdd39f345"
-    },
-    {
-        "url": "https://picsart.com/ai-image-generator/",
-        "title": "Picsart AI",
-        "description": "Picsart推出的AI图片生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a7fe2986-dd4d-4ef6-8277-8d56edaac582.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "aea480b0-7af5-4bed-b051-8f91408c403e"
-    },
-    {
-        "url": "https://completeaitraining.com/ai-tools/neural-love/",
-        "title": "neural.love",
-        "description": "AI艺术图片生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a6761d7-8bc0-4430-ae2a-b257e69bbacc.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "a818d2c5-b060-4a8c-b10f-f4be91ff5b08"
-    },
-    {
-        "url": "https://faq.starryai.com",
-        "title": "starryai",
-        "description": "AI艺术图片生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f970cc2-25fd-441c-95c2-cb635611f513.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "94d9463d-b711-4fe9-be9f-7a09278ee4bc"
-    },
-    {
-        "url": "https://www.artsy.net/",
-        "title": "Artssy",
-        "description": "AI图像生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ffba2bc-5e2c-4bb9-906d-f49e0b71ae9f.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "8b56978f-9e3f-41db-a6e4-29abd7369b51"
-    },
-    {
-        "url": "https://www.playform.io/",
-        "title": "Playform",
-        "description": "专业的高质量AI艺术画生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c8f26b7e-b3f7-4525-ac23-bf187b4806a1.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "2a69d677-5b51-4548-9f5b-3b0e98144941"
-    },
-    {
-        "url": "https://cn.bing.com/images/search?q=photo+booth+by+magic+studio&qpvt=Photo+Booth+by+Magic+Studio&FORM=IGRE",
-        "title": "Photo Booth by Magic Studio",
-        "description": "AI创建个人资料图片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2658f484-0441-4267-87c8-a21b6a196404.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "4b1969a9-f8d9-4b79-bdc1-766a1e9de66a"
-    },
-    {
-        "url": "https://supermeme.ai/",
-        "title": "Supermeme",
-        "description": "AI MEME梗图生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e11bb5a7-8da1-46a9-a47f-8451d39eb2bb.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "17ccc371-38cf-4439-94ce-1bc863b20aa5"
-    },
-    {
-        "url": "https://www.fotor.com/features/ai-image-generator/",
-        "title": "Fotor",
-        "description": "Fotor推出的在线AI图片生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c103578f-890a-47ac-9dd7-ec5660192f54.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "254560a4-d700-4ab7-b768-bf8c1443e26b"
-    },
-    {
-        "url": "https://help.dream.ai/hc/en-us",
-        "title": "Dream.ai",
-        "description": "WOMBO推出的AI艺术画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efa7fa4d-ce52-4730-a84e-2ecceded8450.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "d10f52d2-21e7-45ca-8ec5-ec5f02c91e3c"
-    },
-    {
-        "url": "https://www.wujieai.com",
-        "title": "无界AI",
-        "description": "AI生成艺术插画和二次元人物",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/375f8fae-b0ec-4153-af67-405e2fa199f3.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "bfc9dc96-8ac1-472f-bc69-03af4e532ead"
-    },
-    {
-        "url": "https://www.zcool.com.cn/ailab",
-        "title": "站酷梦笔",
-        "description": "国内知名设计社区站酷推出的人工智能插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/738bbcac-ea75-44ed-a450-fb0d943d8f46.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "aa067d4a-024a-4076-b116-74db282fa361"
-    },
-    {
-        "url": "https://www.gaituya.com/aiimg/",
-        "title": "改图鸭AI图片生成",
-        "description": "改图鸭AI图片生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/320e8cd6-0234-4a98-bb99-a087cbef7870.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "b59d9435-b852-45d4-aac7-17c1e05042c8"
-    },
-    {
-        "url": "https://prodia.com/",
-        "title": "Prodia",
-        "description": "AI艺术画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96b0903d-2d31-4bbf-ad2e-47bba346913c.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "074578c7-3f0e-49a1-95ca-39d07191ae73"
-    },
-    {
-        "url": "https://lucidpic.com/ai-stock-photo-generator",
-        "title": "Lucidpic",
-        "description": "AI生成高质量人像照片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4b7bd73-0dd0-4f01-b733-1738a017b8e8.png",
-        "category": [
-            "图片插画生成"
-        ],
-        "type": "web",
-        "id": "ff67da0d-ec3b-45ea-89f5-5078d10dff53"
-    },
-    {
-        "url": "https://tusiart.com/template/807760005523577813",
-        "title": "吐司AI抠图",
-        "description": "吐司AI推出的智能抠图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a037d356-6c72-45cc-8c2d-8d0fb338e1bf.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "74ab5c2d-7ac4-49ed-ad61-060689b7c412"
-    },
-    {
-        "url": "https://cutout.designkit.com",
-        "title": "美图抠图",
-        "description": "美图秀秀推出的AI智能抠图工具，一键移除背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfee7b65-7f59-4d88-aa4c-ae6ff25595dd.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "8c5c8d3d-49aa-472b-bb9c-939c8fbe1eb4"
-    },
-    {
-        "url": "https://www.gaoding.com",
-        "title": "稿定AI抠图",
-        "description": "AI自动去水印、消除背景工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84603ee7-09ae-4b4c-a240-85c6fce6c418.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "fee03b1d-03d5-456d-9ce2-8aad68c4e793"
-    },
-    {
-        "url": "https://www.piccopilot.com/create",
-        "title": "Pic Copilot AI抠图",
-        "description": "Pic Copilot推出的AI抠图工具，支持批量抠图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/907398a5-51cd-443d-9113-24d04b82282a.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "ceece106-1bd9-46ad-8e6f-3999c464dd98"
-    },
-    {
-        "url": "https://kt.94xy.com",
-        "title": "鲜艺AI抠图",
-        "description": "免费AI抠图工具，支持离线安装使用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b27a8a41-8746-46db-af66-7c7da72e74c4.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "f64a5dfd-79a5-490c-ab14-d6b027eb991d"
-    },
-    {
-        "url": "https://pixian.ai",
-        "title": "Pixian.AI",
-        "description": "免费的AI图片背景抠除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7af2966f-f6e2-47cd-8ef3-c94981099bc8.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "c3ddfbc4-a358-413a-b956-c83d3b88467c"
-    },
-    {
-        "url": "https://d.design/toolbox/cutout",
-        "title": "顽兔抠图",
-        "description": "阿里推出的一键去除商品图背景工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e1e95609-fe20-44e3-99b4-94cf394e29dd.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "54116d91-fe8e-48ea-a08c-2d57ace3a135"
-    },
-    {
-        "url": "https://icons8.com/bgremover",
-        "title": "Icons8 Background Remover",
-        "description": "Icons8出品的免费图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/866d5b8a-bb68-433d-b562-bbcf1bbf92fa.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "7f4b12a8-a2b6-4419-85c9-d5133fe8c3d7"
-    },
-    {
-        "url": "https://bgsub.cn/",
-        "title": "BgSub",
-        "description": "免费的保护隐私的AI图片背景去除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ee90cc8-2d99-468a-a356-7e3f5fa55bb9.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "3d5002c6-5f85-4280-bffa-66406b8ebba6"
-    },
-    {
-        "url": "https://clipdrop.co/remove-background",
-        "title": "ClipDrop Remove Background",
-        "description": "ClipDrop出品的AI图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1768ed02-c244-42fd-ae9f-f01bef1cc5b3.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "016a61df-ad2f-416e-9b00-7216cb211b2c"
-    },
-    {
-        "url": "https://www.erase.bg/zh",
-        "title": "Erase.bg",
-        "description": "在线抠图和去除图片背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e327996f-4702-41ae-ba87-0e8c10845e80.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "4b331576-e036-43ee-a3d0-34963675da3b"
-    },
-    {
-        "url": "https://hisheai.com",
-        "title": "千图设计室AI助手",
-        "description": "AI绘画抠图工具集",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6a79abf-0486-4ea9-bb48-cf5e0e7313d7.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "300e741c-e226-464e-a9c6-016fcbdf35f0"
-    },
-    {
-        "url": "https://www.adobe.com/express/feature/image/remove-background",
-        "title": "Adobe Image Background Remover",
-        "description": "Adobe Express的图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d7ad478e-354b-48fe-b82c-c94b0efca313.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "1fc41712-0a75-432a-b221-f62d772c107a"
-    },
-    {
-        "url": "https://removal.ai/",
-        "title": "Removal.AI",
-        "description": "AI图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dbc60e3b-18ee-4bd0-ba0c-e50a77ffb3b0.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "67752ae4-47c5-4fdc-85f1-0636594a389e"
-    },
-    {
-        "url": "https://magicstudio.com/zh/backgrounderaser",
-        "title": "Background Eraser",
-        "description": "AI自动删除图片背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1e149fb7-7f41-480d-af6c-c5670f7c8564.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "b7b2a9b4-a0a9-47bb-bc0a-52640cd5d8d0"
-    },
-    {
-        "url": "https://www.slazzer.com/",
-        "title": "Slazzer",
-        "description": "免费在线抠除图片背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ab5ce42-2976-4432-84ac-b28c9efaa1c0.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "1d582c40-a009-4893-a057-7d668e87f733"
-    },
-    {
-        "url": "https://www.cutout.pro/zh-cn/remove-background",
-        "title": "Cutout.Pro抠图",
-        "description": "AI批量抠图去背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ee659df-964f-4ef7-a148-7b9213b0bcc0.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "7078150e-9be7-48bf-8c8e-a1e37c0e1957"
-    },
-    {
-        "url": "https://bgremover.vanceai.com/",
-        "title": "BGremover",
-        "description": "Vance AI推出的图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/87dcff6b-74ab-428c-a4f9-0b1becbd9cba.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "9b6edf65-9775-4c61-9c7d-01cee7335d5a"
-    },
-    {
-        "url": "https://tools.picsart.com/image/background-remover/",
-        "title": "Quicktools Background Remover",
-        "description": "Picsart旗下的Quicktools推出的图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fd455ddb-9d02-4e72-a36f-b9439803a056.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "80127029-b798-42a9-99f1-63db11382d8e"
-    },
-    {
-        "url": "https://zyro.com/tools/image-background-remover",
-        "title": "Zyro AI Background Remover",
-        "description": "Zyro推出的AI图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ed676c3-935e-4002-82c9-1223327de5a5.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "ccf07240-ff65-48db-a3a7-dbcbdb960174"
-    },
-    {
-        "url": "https://photoscissors.com/",
-        "title": "PhotoScissors",
-        "description": "免费自动图片背景去除",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24346910-14dd-407f-9c19-82a3bd6f95fd.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "e07c8b60-8e69-4c6d-8d3c-7d709d6e0be6"
-    },
-    {
-        "url": "https://www.yijiankoutu.com/",
-        "title": "一键抠图",
-        "description": "在线一键抠图换背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4ceace52-b9a3-4498-a418-1312a097ff2f.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "5a3d6f45-7e17-4564-ab98-6ed4cf384a07"
-    },
-    {
-        "url": "https://clippingmagic.com/",
-        "title": "ClippingMagic",
-        "description": "魔术般地去除图片背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89f0e0b5-6b62-43c0-b495-d80a6c1b8347.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "0198c11d-f0e0-4d8b-ace6-571a5afbdcad"
-    },
-    {
-        "url": "https://www.tukeli.net/",
-        "title": "图可丽",
-        "description": "AI图片和视频抠图，一键抠图神器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/784de0e2-46c5-4a9d-9925-90f4e9d16e0d.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "58b1d07c-9b55-458a-b62b-c0a00bbf451b"
-    },
-    {
-        "url": "https://hotpot.ai/remove-background",
-        "title": "Hotpot AI Background Remover",
-        "description": "Hotpot.ai推出的图片背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/652fd440-2169-40bd-b94c-9fb75eee0c65.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "d1641303-cfd0-485c-8a3c-d4a9e02d53d4"
-    },
-    {
-        "url": "https://www.stylized.ai/",
-        "title": "Stylized",
-        "description": "AI产品图背景替换",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/793e4d2b-49eb-4d29-992e-af9fa6ea68fd.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "db5696d3-7fbe-4442-a286-b890a2bad544"
-    },
-    {
-        "url": "https://www.booth.ai/",
-        "title": "Booth.ai",
-        "description": "高质量AI产品展示效果图生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b1b60d8-31ff-417a-8173-67afce0ea697.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "91862734-46ab-48d3-ba17-ee18f41643a7"
-    },
-    {
-        "url": "https://www.pixelcut.ai/",
-        "title": "Pixelcut.ai",
-        "description": "AI产品背景移除和替换",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a09f6bb-2e55-4041-85bd-014f319f23a6.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "e29170ca-089a-4e9d-84b1-7a31aaa62613"
-    },
-    {
-        "url": "https://picwish.com/",
-        "title": "PicWish",
-        "description": "AI图片编辑和背景移除",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14e763e6-40e1-4cbe-8cce-d9b2f90dbe46.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "ca00c45d-5be5-474b-a18b-de5167dfde86"
-    },
-    {
-        "url": "https://www.photoroom.com/zh",
-        "title": "PhotoRoom",
-        "description": "免费的AI图片背景移除和添加",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/03318867-955c-4ef6-9463-22ccade8460e.png",
-        "category": [
-            "背景消除"
-        ],
-        "type": "web",
-        "id": "241694fc-aad8-45ad-99ef-a15e915168bf"
-    },
-    {
-        "url": "https://icons8.com/goprod",
-        "title": "GoProd",
-        "description": "Icons8推出的智能图片背景移除和无损放大二合一Mac应用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01ef023a-ac19-481b-99d4-f4ee6c35dd18.png",
-        "category": [
-            "背景消除",
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "683b53ea-565a-4ac5-8c58-70d416dc311f"
-    },
-    {
-        "url": "https://tusiart.com/template/820721890405622530",
-        "title": "吐司AI高清",
-        "description": "吐司AI推出的图片变高清/修复工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79141565-d1d9-4724-ae46-01d2ed88e858.png",
-        "category": [
-            "图片无损放大",
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "493a8f6b-f4c1-45a4-ac2d-1bc7b12beab3"
-    },
-    {
-        "url": "https://www.meijian.com/mj-box/ai-pic-zoom-intro",
-        "title": "美间AI无损放大",
-        "description": "免费的AI图片放大、变清晰工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01879bd5-1f19-475f-9773-46ff4c2821ed.png",
-        "category": [
-            "图片无损放大",
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "facba1ff-4a94-41a2-ba60-5d5da528d898"
-    },
-    {
-        "url": "https://www.designkit.com/upscale",
-        "title": "美图无损放大",
-        "description": "美图设计室推出的AI图片变清晰工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24733e5e-9743-4996-8e48-0a1db6334295.jpg",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "3710ef68-1dcc-4bba-9e2c-7c221324a905"
-    },
-    {
-        "url": "https://bigjpg.com/",
-        "title": "BigJPG",
-        "description": "免费的在线图片无损放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac3641d4-4876-4579-b38f-6c013d3d0bcd.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "e91329f6-2b42-4e8e-9cf8-f734ba830c77"
-    },
-    {
-        "url": "https://mejorarimagen.org",
-        "title": "Mejorar Imagen",
-        "description": "AI图像放大增强工具，快速放大至10倍或12K分辨率",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/44f352ed-e566-4373-a562-9c6f2357a81a.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "cb8a2242-5aac-4779-9031-cb72b8dc24ad"
-    },
-    {
-        "url": "https://magnific.ai",
-        "title": "Magnific AI",
-        "description": "强大的AI图像放大工具，最高支持到10K分辨率",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/60deee4b-2dc7-43c3-a4cb-54b89dd5c54f.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "32b152d7-30ae-4221-920b-ea25a289c468"
-    },
-    {
-        "url": "https://letsenhance.io",
-        "title": "Let’s Enhance",
-        "description": "AI在线免费放大图片并保持图像质量",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79f934bf-5bfb-44d3-8fb9-b1dfe539b90c.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "c47b4d5d-3748-449f-a360-f18de2430881"
-    },
-    {
-        "url": "https://icons8.com/upscaler",
-        "title": "Icons8 Smart Upscaler",
-        "description": "Icons8出品的AI图片无损放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/544e5ca3-9b8b-41b3-ba9b-7d67271c3a4d.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "ee658661-0839-478c-b5bc-cc6a07e2ec47"
-    },
-    {
-        "url": "https://clipdrop.co/image-upscaler",
-        "title": "ClipDrop Image Upscaler",
-        "description": "ClipDrop出品的AI图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d4a6b50-170f-471e-8aed-1af19ca7276b.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "7ecde005-8336-477a-ab82-2e80d0948dfb"
-    },
-    {
-        "url": "https://imgupscaler.com/",
-        "title": "Img.Upscaler",
-        "description": "免费的AI图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d0b2321-751a-4976-a2e8-76433cbeaefe.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "616832c8-d133-46a0-b876-238a49170d67"
-    },
-    {
-        "url": "https://www.fotor.com/image-upscaler/",
-        "title": "Fotor AI Image Upscaler",
-        "description": "Fotor推出的AI图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3439d6cd-e90a-492a-9da6-f1d071922347.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "83ce9680-dfe8-4456-853d-bd765d4c65f2"
-    },
-    {
-        "url": "https://zyro.com/tools/image-upscaler",
-        "title": "Zyro AI Image Upscaler",
-        "description": "Zyro出品的人工智能图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21902e02-66cd-4bf6-ae8d-1b990fe3ccf9.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "eba8ebce-1336-4b24-a1b6-878ab7b4e7f8"
-    },
-    {
-        "url": "https://www.media.io/image-upscaler.html",
-        "title": "Media.io AI Image Upscaler",
-        "description": "Media.io推出的AI图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fbf86bd9-811e-4f9c-88d0-eb6f3a01c109.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "6e753f93-11ee-4b90-9449-09314098d2c7"
-    },
-    {
-        "url": "https://www.upscale.media/zh",
-        "title": "Upscale.media",
-        "description": "AI图片放大和分辨率修改",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a3741d7-f0c9-485f-abec-6b6ac5befdef.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "60575492-f710-43fe-8657-96c47258b0e2"
-    },
-    {
-        "url": "https://ai.nero.com/image-upscaler",
-        "title": "Nero Image Upscaler",
-        "description": "AI免费图片无损放大",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff7efcca-e518-41e0-82f5-fe5cd85118fe.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "0493412c-58db-445e-9fe0-491f583ecfeb"
-    },
-    {
-        "url": "https://vanceai.com/image-resizer/",
-        "title": "VanceAI Image Resizer",
-        "description": "VanceAI推出的在线图片尺寸调整工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8902355d-a7d9-4d8d-a4bb-ad74faf7a85a.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "2dea4a88-bbf0-44a0-9dd8-0017df3e2ed5"
-    },
-    {
-        "url": "https://photoaid.com/en/tools/ai-image-enlarger",
-        "title": "PhotoAid Image Upscaler",
-        "description": "PhotoAid出品的免费在线人工智能图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/956ff2cd-53f5-43cd-b6b9-ec76ea16d6da.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "341f6e44-4f1d-40f8-9136-77dae4c67911"
-    },
-    {
-        "url": "https://upscalepics.com/",
-        "title": "Upscalepics",
-        "description": "在线图片放大工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/809ef8f2-43a6-4602-8b66-c10013198b04.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "14d1c948-f3a9-4e62-8262-c8ded9ef8290"
-    },
-    {
-        "url": "https://magicstudio.com/zh/enlarger",
-        "title": "Image Enlarger",
-        "description": "AI无损放大图片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac47aa1a-0bb6-445a-9766-cd6fa373a409.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "45ec8858-7f7c-4b9b-9822-f57def3c211f"
-    },
-    {
-        "url": "https://pixelhunter.io/",
-        "title": "Pixelhunter",
-        "description": "AI智能调整图片尺寸用于社交媒体平台发帖",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/35b0ca71-bf69-44b2-a44e-c507633fcd76.png",
-        "category": [
-            "图片无损放大"
-        ],
-        "type": "web",
-        "id": "37aab609-7a5e-4b03-8519-9728603eb025"
-    },
-    {
-        "url": "https://yunxiu.meitu.com/",
-        "title": "美图云修",
-        "description": "美图秀秀推出的一站式AI智能修图软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/23176d46-3732-4023-ad3b-70c09b64dadd.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "f07f786f-f1f5-4036-9f9f-3ba9a085b3ae"
-    },
-    {
-        "url": "https://remini.ai",
-        "title": "Remini",
-        "description": "AI智能将模糊照片变高清的图像修复工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3b625362-35a0-4f1e-927a-475e97b3f343.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "a8a1270b-2f70-46ba-965f-3f2af59b119c"
-    },
-    {
-        "url": "https://jpghd.com/zh",
-        "title": "jpgHD",
-        "description": "人工智能老照片上色和修复",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/91766c12-337b-42f4-8a53-164aa8729166.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "5297f888-5c1c-46ab-b796-e25b3eee44b3"
-    },
-    {
-        "url": "https://www.pixcakeai.com",
-        "title": "像素蛋糕PixCake",
-        "description": "简单易用的AI图像精修工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1534bc40-cb83-40f5-8f09-05cf1fcf77c4.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "1441f8f4-1979-4dbb-9da1-e6b943518249"
-    },
-    {
-        "url": "https://www.aixtsy.com",
-        "title": "咻图AI",
-        "description": "面向影楼的摄影后期AI修图软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01047cf0-364c-42db-8b89-37f4db2909c3.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "225d0113-8221-4c66-bb58-e554b9c69a90"
-    },
-    {
-        "url": "https://www.restorephotos.io/",
-        "title": "restorePhotos.io",
-        "description": "AI老照片修复",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c10b669-bdc8-4be9-a667-9b6550177ba3.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "64c0efc7-28f3-4958-9b84-3d3295b9a3b5"
-    },
-    {
-        "url": "https://picma.magictiger.ai/zh",
-        "title": "PicMa Studio",
-        "description": "AI一键批量增强、修复、彩色化你的照片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b244c3a9-a778-44f6-8e4f-9f48b390cb6e.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "0f84b41a-f306-4039-83fb-48fa403ce932"
-    },
-    {
-        "url": "https://transpic.cn",
-        "title": "transpic",
-        "description": "AI图像转绘插画创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a1f735c3-0d43-4018-ab98-2ae0040b089f.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "573926c1-e6bf-4b53-96cb-44882d9daaf0"
-    },
-    {
-        "url": "https://www.cutout.pro/zh-CN/photo-colorizer-black-and-white",
-        "title": "Cutout.Pro老照片上色",
-        "description": "Cutout.Pro推出的黑白图片上色",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/647e960f-a7ca-4c57-a7b7-126babcfd480.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "f6183cad-53e9-402c-8497-1d9b27f33787"
-    },
-    {
-        "url": "https://palette.fm/",
-        "title": "Palette",
-        "description": "AI图片调色上色",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b9754579-0481-4597-9dbb-e7614346c3ac.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "1b38a85d-4510-4a3e-bee9-e91e290058c4"
-    },
-    {
-        "url": "https://playgroundai.com/",
-        "title": "Playground AI",
-        "description": "AI图片生成和修图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0eddef75-d42c-4d15-9a30-ecd21c0fe3f4.png",
-        "category": [
-            "图片优化修复"
-        ],
-        "type": "web",
-        "id": "d73580dc-1714-437f-b34a-c969c7aa592c"
-    },
-    {
-        "url": "https://www.ihuiwa.com/workspace/ai-image/partial-redraw?editType=eraser-pen",
-        "title": "绘蛙AI消除",
-        "description": "免费AI修图工具，一键去除图片中多余元素",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ab55966a-c3bb-492f-94d2-9aaa47c4c35e.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "bf9b5613-b8e3-4c6b-a68c-2c00e2838f21"
-    },
-    {
-        "url": "https://www.meijian.com/mj-box/ai-eliminate-intro",
-        "title": "美间AI消除",
-        "description": "AI智能消除工具，轻松消除杂物、水印等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6ca69b24-5c63-4ef8-8391-9125e30e02a8.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "029f8d14-93a4-466a-b549-e20c816bf0a3"
-    },
-    {
-        "url": "https://www.designkit.com/aieraser/?channel=100102",
-        "title": "美图AI消除",
-        "description": "美图设计室推出的AI消除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac74771e-f158-4777-bede-092de0571f20.jpg",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "a9694778-3b09-4075-b0b6-603e2458a8c0"
-    },
-    {
-        "url": " https://tusiart.com/template/820385276638620489",
-        "title": "吐司AI消除",
-        "description": "吐司AI推出的AI智能消除、去杂物工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/95045c61-31f1-4e7c-9850-e0bd6f5c0a82.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "36109912-58e7-46bc-bafc-1051146bf322"
-    },
-    {
-        "url": "https://www.hama.app/zh",
-        "title": "Hama",
-        "description": "在线抹除图片中不想要的物体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1a192675-0076-4919-8cc2-b3a587238a08.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "ae0e2855-8e09-4c80-a327-a801c6ac69e9"
-    },
-    {
-        "url": "https://www.iopaint.com",
-        "title": "IOPaint",
-        "description": "免费开源的AI图像擦除、修复和处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b893aaa5-70e4-4102-bd00-c19e1e45ab5f.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "2c2ad32a-8e5f-416d-bfe1-7d8c153d91f8"
-    },
-    {
-        "url": "https://bgeraser.com/",
-        "title": "Bg Eraser",
-        "description": "图片物体抹除和清理",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4375c0f8-a69e-4821-9948-284cd08f8c21.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "8a83df36-44f0-4f68-baba-c956497a7a58"
-    },
-    {
-        "url": "https://snapedit.app/",
-        "title": "SnapEdit",
-        "description": "AI移除图片中的任何物体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39862892-b50d-4a24-9542-86d4d00a1b6e.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "29810234-cf2a-4153-a4bb-7242e9bda0e4"
-    },
-    {
-        "url": "https://cleanup.pictures/",
-        "title": "Cleanup.pictures",
-        "description": "智能移除图片中的物体、文本、污迹、人物或任何不想要的东西",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51fc32f8-02d5-4feb-8ccd-e7a039dc27e1.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "28d87638-f0ba-4712-8edd-f4273bbd9250"
-    },
-    {
-        "url": "https://www.cutout.pro/zh-CN/image-retouch-remove-unwanted-objects",
-        "title": "Cutout.Pro Retouch",
-        "description": "Cutout.Pro推出的AI图片物体涂抹去除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d026f4ac-274d-4048-a31b-2112c6c4f60c.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "4768d5a5-ef91-48a5-9b9e-9b5477b64bf7"
-    },
-    {
-        "url": "https://beecut.cn/online-watermark-remover",
-        "title": "蜜蜂剪辑",
-        "description": "AI去水印工具，支持图片和30+流行短视频平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/babc1a96-7b81-4d1a-903d-308b252649f6.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "a22a1800-aabb-4403-9c70-71fadacc2353"
-    },
-    {
-        "url": "https://www.hitpaw.com/remove-watermark.html",
-        "title": "HitPaw Watermark Remover",
-        "description": "AI图片和视频去水印工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82470d54-24fa-4b0d-b1ee-b0266a484417.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "341e9e87-a93b-433d-a747-12f737879312"
-    },
-    {
-        "url": "https://magicstudio.com/zh/magiceraser",
-        "title": "Magic Eraser",
-        "description": "AI移除图片中不想要的物体",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8dc5c36c-3432-4c2b-90e4-7c167a38f554.png",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "00855aef-3c8b-4a27-99e4-8faed791eef8"
-    },
-    {
-        "url": "https://www.watermarkremover.io/zh",
-        "title": "WatermarkRemover",
-        "description": "AI智能删除照片中的水印",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/90244bc9-1645-4d67-bbf9-7da90bd16ad3.jpg",
-        "category": [
-            "图片物体擦除"
-        ],
-        "type": "web",
-        "id": "d5d66bbc-62ac-4964-b763-4b57b8a0d2e7"
-    },
-    {
-        "url": "https://www.meijian.com/e-commerce",
-        "title": "美间AI商拍",
-        "description": "AI电商设计工具，一键生成高质量商品图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f10be9bd-3967-4c5f-9d68-d10b648c4e0f.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "3dc82530-db59-433a-8e57-52f74192eea2"
-    },
-    {
-        "url": "https://www.designkit.com/product-shoot/?channel=100103",
-        "title": "美图商拍",
-        "description": "美图设计室推出的AI商拍工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f60928e-7239-478e-9645-b9f9c6caafb5.jpg",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "ce3a824f-1b43-4731-b31d-785379241316"
-    },
-    {
-        "url": "https://fengniaoai.com",
-        "title": "蜂鸟AI",
-        "description": "赶海科技推出的跨境电商AI营销工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d6d61aae-ca75-4cd4-9e8b-42b933e8f53c.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "ad20a0c6-cd33-4565-bd55-2195b6326f1e"
-    },
-    {
-        "url": "https://psai.cn",
-        "title": "PhotoStudio AI",
-        "description": "虹软旗下推出的AI商拍工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e93f3940-ebe5-4f6c-9a4b-546563ecddb9.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "9616c7ec-bb27-4201-aa53-12a7c77fc3db"
-    },
-    {
-        "url": "https://www.cliclic.ai",
-        "title": "Cliclic AI",
-        "description": "创客贴推出的AI商品图生成和编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dec91ebf-9739-4f90-893e-e69c6680a4e4.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "982bd9a3-f59d-4327-8000-69a326aad950"
-    },
-    {
-        "url": "https://ai.linkfox.com",
-        "title": "LinkFox AI",
-        "description": "AI电商设计工具，快速生成专业电商图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53796cd7-13c6-4ebc-8fcd-ea59b0e20493.jpg",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "ba5a3569-5ecd-481d-92a8-05e0c0ecce5e"
-    },
-    {
-        "url": "https://chuangziyou.com",
-        "title": "创自由",
-        "description": "快速设计商品图、广告图的AI作图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/584227a6-1783-4316-bd99-7e558ac4ae47.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "367a3ddb-164f-4272-ba31-c994d8765337"
-    },
-    {
-        "url": "https://ling.jd.com/",
-        "title": "羚珑",
-        "description": "京东推出的商品图智能设计小工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94052e53-2426-4bfe-b1ea-229ea76cbd75.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "7558868a-2c3f-4cb7-a5a4-5b8014dee91a"
-    },
-    {
-        "url": "https://www.redoon.cn",
-        "title": "灵动AI",
-        "description": "专业的AI商品图生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3abcecdf-1db6-4a89-b499-c2e326f3c569.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "7c16b573-4b51-4ef9-a006-aa61a3e9fe13"
-    },
-    {
-        "url": "https://www.photomagic.cn",
-        "title": "PhotoMagic",
-        "description": "AI快速生成商拍图片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebfde73e-08b9-433e-a8fd-7484d206dfe6.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "e47ed423-c29d-4cf7-84f8-6ecad357c93d"
-    },
-    {
-        "url": "https://pebblely.com/",
-        "title": "Pebblely",
-        "description": "AI产品图精美背景添加",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d894122-6497-42fc-81c9-739e05603983.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "77d3aeb5-0bec-4f07-aa5a-5c6cbce75d2e"
-    },
-    {
-        "url": "https://mokker.ai/",
-        "title": "Mokker AI",
-        "description": "AI产品图添加背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1ba2f356-6c6d-4af0-a1d6-61c3a19d1a4a.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "9585cbf0-c2f8-4e9e-ae6e-a5466cee2d3c"
-    },
-    {
-        "url": "https://www.hsphoto.cn",
-        "title": "花生图像",
-        "description": "AI电商产品图生成和背景抠图工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4f2f151-8f2d-4090-9474-3b34d13028d2.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "2225b9f4-4578-4f7c-ae83-80b54fff3bc7"
-    },
-    {
-        "url": "https://tushengsheng.com/home",
-        "title": "图生生",
-        "description": "专为电商设计的AI商拍工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c734daf9-eee2-4d75-9843-f7b6476ef5ec.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "8a01acb2-5cde-49c7-9446-cdf4e1552887"
-    },
-    {
-        "url": "https://www.weshop.com",
-        "title": "WeShop唯象",
-        "description": "蘑菇街推出的AI商拍工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2812c4c-8e7a-46ee-bb36-1a8cc92ccd45.png",
-        "category": [
-            "商品图生成"
-        ],
-        "type": "web",
-        "id": "f4ca0520-9a5d-4632-a13f-2cdb8ab7d02b"
-    },
-    {
-        "url": "https://www.tripo3d.ai",
-        "title": "Tripo AI",
-        "description": "AI 3D模型生成平台，支持文本、图像一键生成3D模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f7f54356-c530-4a61-800f-2374220e3078.png",
-        "category": [
-            "3D模型生成"
-        ],
-        "type": "web",
-        "id": "4bd462e5-326e-4172-9318-7e8cd8e8a5eb"
-    },
-    {
-        "url": "https://3d.hunyuan.tencent.com",
-        "title": "腾讯混元3D",
-        "description": "腾讯推出的一站式3D内容生产AI创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/582fdc9f-fc7b-42e0-9718-cf12e31c7294.png",
-        "category": [
-            "3D模型生成"
-        ],
-        "type": "web",
-        "id": "8602750f-cea0-4808-ac96-8871749b9cab"
-    },
-    {
-        "url": "https://hitems.ai",
-        "title": "Hitems",
-        "description": "数美万物推出的AI创意物品生成社区",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e098e5c9-78c7-44db-8b1a-e5087cf79c62.png",
-        "category": [
-            "3D模型生成"
-        ],
-        "type": "web",
-        "id": "7cceffe5-477e-4eab-bc11-8e694b2812c0"
-    },
-    {
-        "url": "https://voxcraft.ai",
-        "title": "VoxCraft",
-        "description": "AI生成3D模型的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d63508e-af94-4d59-b290-fd396ca61eb8.png",
-        "category": [
-            "3D模型生成"
-        ],
-        "type": "web",
-        "id": "4e3ab9e2-86fc-4fbe-9f4b-edfc8621b49a"
-    },
-    {
-        "url": "https://www.meshy.ai",
-        "title": "Meshy",
-        "description": "AI快速从文本或图像生成3D模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6342ac89-e353-4aa2-a4cb-a21fc07abbba.png",
-        "category": [
-            "3D模型生成"
-        ],
-        "type": "web",
-        "id": "ed6c3928-1b8a-4ab1-91f8-8e3fdd63ceae"
-    },
-    {
-        "url": "https://aibrm.paluai.com/bairimeng",
-        "title": "白日梦",
-        "description": "AI视频创作平台，最长可生成六分钟的视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2b0dd74-0704-4bee-9d91-5b40719b1410.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "d731df3d-4ad7-47e4-b543-bc630005db73"
-    },
-    {
-        "url": "https://www.ihuiwa.com/workspace/ai-video/custom-action",
-        "title": "绘蛙AI视频",
-        "description": "绘蛙推出的AI图生视频工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d0cff68f-310a-40c1-a980-08ef3d64c4a7.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "7edf01ab-f831-4ca8-af89-6d44ba787a2d"
-    },
-    {
-        "url": "https://typemovie.art",
-        "title": "讯飞绘镜",
-        "description": "科大讯飞推出的AI短视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/705c3ac7-1c42-41fb-9bb1-378198bb6937.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "d6c538a9-72b6-47c2-8940-6ebd289e86b3"
-    },
-    {
-        "url": "https://www.vidu.cn",
-        "title": "Vidu",
-        "description": "生数科技推出的AI视频生成大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0e750f86-c001-4332-93ab-6173e006e469.jpg",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "4da6849e-ffba-4298-b2ee-98d6f2305eac"
-    },
-    {
-        "url": "https://soundviewai.com",
-        "title": "SoundView",
-        "description": "AI视频本地化工具，支持视频配音和翻译",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a48d2d11-18c4-4a5d-80bf-5f257bce1e98.jpg",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "d88b19ae-cefb-4ffa-84a5-e0f75232e750"
-    },
-    {
-        "url": "https://heygen.com",
-        "title": "HeyGen",
-        "description": "AI数字人视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/916064d3-002c-4fef-b744-f49a9125acf7.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "6451147a-4909-428b-b7d6-a1e3ac57a880"
-    },
-    {
-        "url": "https://www.youyan3d.com/platform",
-        "title": "有言",
-        "description": "一站式AI视频创作和3D数字人生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f74145c7-7ec2-44b8-96a6-fb1a8831074b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ec1c23b8-7775-4504-8394-bdaa331c6f0e"
-    },
-    {
-        "url": "https://jurilu.paluai.com",
-        "title": "巨日禄",
-        "description": "一站式AI动漫视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/906b7d02-557b-4c8d-8494-c8413ae52003.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a6d7f824-de34-45e9-9be3-f6dc13c5ab73"
-    },
-    {
-        "url": "http://dis.csqixiang.cn/unpo/jimeng_1.html",
-        "title": "即梦AI",
-        "description": "字节跳动推出的一站式AI创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8c3efb2-cf24-482a-bac2-da57b84d69a2.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "3957a872-33be-4daa-b4e7-6885b2880337"
-    },
-    {
-        "url": "https://chatglm.cn/video?lang=zh",
-        "title": "智谱清影",
-        "description": "智谱推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c85ad14-5119-45c6-8e4e-620b733df9bc.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5c44a41f-13cc-4038-910e-72458d39d343"
-    },
-    {
-        "url": "https://video.hunyuan.tencent.com",
-        "title": "腾讯混元AI视频",
-        "description": "腾讯推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2523ea2b-f26c-4894-9e44-0e44206766b4.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "6285e522-3049-474f-8c56-9391a37c2c2b"
-    },
-    {
-        "url": "https://www.kreadoai.com/zh",
-        "title": "KreadoAI",
-        "description": "AI数字人视频营销创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2196fa6-c244-4347-89e5-4b555cf9745c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "46aadc6f-6a55-4f19-9673-cf4399f0786f"
-    },
-    {
-        "url": "https://www.joypix.ai",
-        "title": "JoyPix",
-        "description": "AI数字人创作工具，支持声音克隆",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/104997db-800a-4982-9169-f8c95e0ba05c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5bb0ce54-a83d-419d-bfe5-cd202fbef4d4"
-    },
-    {
-        "url": "https://runwayml.com",
-        "title": "Runway",
-        "description": "AI视频工具，绿幕抠除、视频生成、动态捕捉等功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/adb66c57-c11e-45ae-96b6-d51be9d42543.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "896a8ddb-9b38-42f0-936c-d4371067a91a"
-    },
-    {
-        "url": "https://pika.art/",
-        "title": "Pika",
-        "description": "Pika Labs推出的AI视频生成和编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09746844-4a3a-4560-b46b-74e6a777a195.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "cb90d0a3-fe7c-488d-8e8a-12008d9f25ae"
-    },
-    {
-        "url": "https://lumalabs.ai/dream-machine",
-        "title": "Dream Machine",
-        "description": "Luma AI推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d96f9599-bb5b-4611-a486-8a52eb965ba2.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "4b3ff24e-0388-45c2-973e-f1371d9205fe"
-    },
-    {
-        "url": "https://tongyi.aliyun.com/wanxiang/wanxvideo",
-        "title": "通义万相AI视频",
-        "description": "通义万相AI视频是阿里推出的...",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/246d4d1b-007e-4f8d-a16c-4175e2ac8f22.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "70871082-efc3-4907-9ad0-d9e1046b0496"
-    },
-    {
-        "url": "https://openai.com/sora",
-        "title": "Sora",
-        "description": "OpenAI推出的AI视频生成模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/46882148-fcea-4e0f-8063-e9416bee502f.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "49cafc8b-ef91-4dbd-9551-986275dbd7f0"
-    },
-    {
-        "url": "https://aigc.yizhentv.com",
-        "title": "秒创",
-        "description": "AIGC内容创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ad35fcc-4063-4374-9a33-2d306d3a22f5.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a9ebe9fa-1ab7-4ca0-8466-5b6ea72c3ca5"
-    },
-    {
-        "url": "https://aic.oceanengine.com/",
-        "title": "即创",
-        "description": "抖音推出的一站式AI智能创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39aaf778-34b2-4a6f-91e6-eb1edb53748d.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "bce3bdff-a6ae-4d3c-901a-d45f28d83706"
-    },
-    {
-        "url": "https://www.hedra.com/",
-        "title": "Hedra",
-        "description": "AI对口型视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a0636f50-861c-40bf-bdd4-3c7bf103dc17.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "6405ba4a-b3e4-4734-8c0f-dd34dfe7e546"
-    },
-    {
-        "url": "https://www.vozo.ai/",
-        "title": "Vozo",
-        "description": "多功能AI视频编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9bb136f5-f2c7-49f8-a2f0-954ef8a12e5f.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "b383eebc-dc7c-47b6-aff8-49055cdf5039"
-    },
-    {
-        "url": "https://viggle.ai/",
-        "title": "Viggle",
-        "description": "AI生成可控的角色动态视频的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/221b0b7a-9945-4f5e-8473-3c64cc9cd1b8.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "1692b905-3a20-48b6-b16c-3f8a304d7004"
-    },
-    {
-        "url": "https://www.tavus.io",
-        "title": "Tavus",
-        "description": "AI数字人克隆和AI视频实时对话工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d2d61b74-684b-4d91-806d-a0ead8dc1fcd.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "cc919a9c-708e-478c-97fd-3c9a9e35f5c4"
-    },
-    {
-        "url": "https://yuewen.cn/videos",
-        "title": "跃问视频",
-        "description": "阶跃星辰推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f88ad8c8-aa13-4c3e-852d-48aaebef2887.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ce3d4e9d-9218-4e3f-a6ff-6655f49f2931"
-    },
-    {
-        "url": "https://yuanjing.zeelin.cn/",
-        "title": "元镜",
-        "description": "AI视频生成工具，支持多模态创意分镜创作服务",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d9cc5f3f-6601-4324-ba0a-409165661a84.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "0f532397-8bff-45e8-9fa3-60edc7bcb06c"
-    },
-    {
-        "url": "https://skyreels.ai/beta",
-        "title": "SkyReels",
-        "description": "昆仑万维推出的AI短剧创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/32d95609-1e64-4266-95d3-8416c6c4d621.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "f36d380b-1db3-4214-a6fd-fe2ab68733f2"
-    },
-    {
-        "url": "https://www.moki.cn/",
-        "title": "MOKI",
-        "description": "美图推出的AI视频短片创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/86c58578-e067-4da0-8b93-a721a7f8a55a.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "08938b9f-2db6-4616-b235-17ad18291ec2"
-    },
-    {
-        "url": "https://shenbi.maoyan.com/",
-        "title": "神笔马良",
-        "description": "猫眼娱乐推出的AI影视创作生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7fcc96a3-829c-4164-bbe2-78041af3e5f2.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "3698a707-ef8e-4d1b-aee6-954bf14607f0"
-    },
-    {
-        "url": "https://video.luchentech.com/zh-CN",
-        "title": "Video Ocean",
-        "description": "潞晨科技推出的多功能AI视频生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d18ef03-269e-4c9c-be7d-66cdd690f12d.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "bb3541a2-e6f6-46bc-aee0-5fccae821299"
-    },
-    {
-        "url": "https://flowgpt.com/flow-studio",
-        "title": "Flow Studio",
-        "description": "FlowGPT推出的AI长视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c7591c8-3c8a-46e1-9ed2-f7c7d89bb3d5.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "afb06fff-4107-4e82-87aa-ee1c8c1ba97d"
-    },
-    {
-        "url": "https://vizard.ai/",
-        "title": "Vizard",
-        "description": "将长视频转为社交短视频的AI工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/95640dfd-57f3-45a8-8047-adb3560c6ea0.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "0602a2ae-a342-4b9e-9368-8a9aae0e91ab"
-    },
-    {
-        "url": "https://xunguang.com/",
-        "title": "寻光",
-        "description": "阿里达摩院推出的全流程AI视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b848b135-e552-44c2-9a3a-64104836a6b5.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "013f3c93-d5f5-4de8-ae25-0d0acf7fb5df"
-    },
-    {
-        "url": "https://hotshot.co/",
-        "title": "Hotshot",
-        "description": "AI视频生成工具，将文本转为3秒逼真视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/32e59109-31fc-4e91-84cd-5b14383c4c37.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "b13f8d3a-1215-43c9-9f11-09ed6867519d"
-    },
-    {
-        "url": "https://vivago.ai/",
-        "title": "Viva",
-        "description": "免费的AI视频生成和图像创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/90a0a86e-dc8c-40e7-9322-7126f75c38e9.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5ebe2879-4bb7-4447-abc5-3950ccf0af76"
-    },
-    {
-        "url": "https://humva.ai",
-        "title": "Humva",
-        "description": "AI数字人生成工具，自定义创建专属数字人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6daa62e-d4d5-418c-bf28-7028eec3e5ea.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "aeeeb2bc-f20a-450f-bec0-ddce5f63f797"
-    },
-    {
-        "url": "https://www.d-id.com/",
-        "title": "D-ID",
-        "description": "AI真人口播视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da42e3af-8207-4141-a804-b050a461e5bb.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "3b5cbc63-1478-4641-a2bb-e85c43833d6f"
-    },
-    {
-        "url": "https://www.stablevideo.com/",
-        "title": "Stable Video",
-        "description": "Stability AI推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bef706c0-270d-4d91-a4d0-6ebb7902acc5.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c1f0cefd-64d8-415c-b2ab-f0d293c77fd3"
-    },
-    {
-        "url": "https://onestory.art/",
-        "title": "OneStory",
-        "description": "专业的AI故事生成助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d466a9f4-b84f-4d58-9963-cafcdc10f591.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c9d69a04-248e-4e72-af0c-ee4e1931e7de"
-    },
-    {
-        "url": "https://noisee.ai/",
-        "title": "Noisee AI",
-        "description": "月之暗面旗下推出的AI音乐视频MV生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/05f813c3-296c-4558-8ff7-aa90cb66d8a2.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5d0b1c60-8760-4590-942e-68e387eac4be"
-    },
-    {
-        "url": "https://zenvideo.qq.com/",
-        "title": "腾讯智影",
-        "description": "腾讯推出的AI智能创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e28a2263-9ca2-459b-a079-494dfaf2c3fb.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "6480abb8-df7c-4471-8b8f-08553e076fa1"
-    },
-    {
-        "url": "https://virbo.wondershare.cn/",
-        "title": "万兴播爆",
-        "description": "AI数字人口播视频营销工具，海量素材一键套用",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80ad57ec-da90-4a5e-91aa-051198504ea8.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "29032547-1589-47c6-a51d-6ac84272738d"
-    },
-    {
-        "url": "https://www.sensetime.com/cn/product-detail",
-        "title": "Vimi",
-        "description": "商汤科技推出的可控人物视频生成AI模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6f6956f-2fd1-4892-8daa-e613008938e7.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "d51fcb8a-0f63-4e4f-99a5-d66731cee157"
-    },
-    {
-        "url": "https://etna.7volcanoes.com/",
-        "title": "Etna",
-        "description": "七火山科技推出的AI文生视频工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a17f32f9-ebb2-419c-8b24-7bd3734cd89f.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "8c1b21a3-e648-4863-8610-ecc1eafcc1b7"
-    },
-    {
-        "url": "https://www.artink.art/",
-        "title": "艺映AI",
-        "description": "AI视频创作工具，支持文生视频、图生视频及视频转漫画功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fa951c74-ee28-4c3b-bbf0-e1303058a344.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c626d8f5-617e-47e9-9894-798b428b1107"
-    },
-    {
-        "url": "https://lensgo.ai/",
-        "title": "LensGo",
-        "description": "AI视频创作工具，支持视频转动漫，替换3D人物",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd1b5175-6ede-4642-aa56-7e30381ea551.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c49f3a52-59af-4310-824e-73477d384ef6"
-    },
-    {
-        "url": "https://member.bilibili.com/york/bilibili-studio/",
-        "title": "必剪Studio",
-        "description": "B站推出的免费AI数字分身定制和视频创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6cf93f95-280a-45ac-80e0-a9b900590c50.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "53177e6c-7385-414a-93c3-b11e2929fbd3"
-    },
-    {
-        "url": "https://aigc.baidu.com",
-        "title": "度加创作工具",
-        "description": "百度官方出品的AIGC创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/56e99072-8b12-4123-a722-31e9aafde6c9.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "09522701-e6f5-4049-b020-3006672613ff"
-    },
-    {
-        "url": "https://wink.meitu.com/",
-        "title": "WinkStudio",
-        "description": "美图推出的桌面端AI视频剪辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f9834f78-4015-4fa3-9388-3be6923c409e.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "b21919ab-00b9-4333-a811-b8bdcbc6bea3"
-    },
-    {
-        "url": "https://www.vmagic.app/zh",
-        "title": "VMagic",
-        "description": "AI视频处理平台，提供视频风格转换、换脸、照片舞蹈等功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/537f456c-8743-439a-b555-8a9bb7697bb2.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ddde04ed-b8d3-49bb-a375-0311a084b40b"
-    },
-    {
-        "url": "https://virtual-man.xfyun.cn/",
-        "title": "讯飞虚拟人",
-        "description": "科大讯飞推出的全栈式AI虚拟人应用服务平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39f315a1-99b4-4a14-a982-4dfc940718f9.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "62cc7dd2-8fba-4203-bdf6-7f2dea125d40"
-    },
-    {
-        "url": "https://www.flyworks.live/",
-        "title": "飞影数字人",
-        "description": "AI数字人创作平台，支持免费定制数字人",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cbd3881c-d760-4524-bfe9-4c0db162e988.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "12eb6eee-e0b2-49a2-8cac-652abc510b85"
-    },
-    {
-        "url": "https://www.vidustudio.net/zh",
-        "title": "Video Studio",
-        "description": "在线AI视频制作工具，零编辑技能制作专业视频内容",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7040138f-cd36-4f32-92ad-7cd015ac4b5d.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "9517f41e-6650-4050-9abf-eb658423c235"
-    },
-    {
-        "url": "https://app.pixfun.ai/home",
-        "title": "Pixfun",
-        "description": "一站式动画故事AI视频生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/69e28ddc-b8f3-42ec-8670-5cf6906615b8.jpg",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "18351e1e-ac3e-4018-a1d4-dc634f4f104d"
-    },
-    {
-        "url": "https://www.decohere.ai/",
-        "title": "Decohere",
-        "description": "AI视频生成平台，支持音频同步功能",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cf8da4da-9ad2-4f05-bc36-3a8e43656642.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "af83c19d-acb0-4397-969e-fa8397221269"
-    },
-    {
-        "url": "https://avolutionai.com/",
-        "title": "YoYo",
-        "description": "鹿影科技推出的二次元动漫视频AI创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/af295a2e-fd2f-45c9-af06-9f028fbccdaf.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5b4b92fd-a3dc-4125-9d08-ac926d714add"
-    },
-    {
-        "url": "https://www.opus.pro/",
-        "title": "Opus Clip",
-        "description": "AI视频切片工具，自动从长视频中提取精彩片段",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/391b9ce5-6580-47d7-a7a4-48c711e8ec3e.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "7b51a755-90ba-4701-9ea2-cf9f458d5c87"
-    },
-    {
-        "url": "https://filmora.wondershare.com/",
-        "title": "Filmora",
-        "description": "万兴科技推出的AI视频编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f1c72c7-bf77-45b7-be1d-c238e9811271.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "751a9177-3ef9-4052-8ed9-99b8da349aff"
-    },
-    {
-        "url": "https://www.descript.com/",
-        "title": "Descript",
-        "description": "AI视频编辑工具，支持通过编辑文字来剪辑音视频内容",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8bf3fa60-26af-466e-8de6-43259a8de9b4.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "cc46eb24-0f97-43fc-8cee-54b4da016c63"
-    },
-    {
-        "url": "https://xiling.cloud.baidu.com/",
-        "title": "曦灵",
-        "description": "百度推出的AI数字人和视频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efd58587-4d6d-4b15-abe5-bfd8ef3018e0.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "b9a7f0a2-2c3a-4db5-8663-5677a0d7b37a"
-    },
-    {
-        "url": "https://kaipai.meitu.com/",
-        "title": "开拍",
-        "description": "美图推出的AI口播视频制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/819fc0e1-f35c-4a2b-962a-07e5f489046b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "27817b1f-8205-4cd4-8c4c-f230f1f71c03"
-    },
-    {
-        "url": "https://www.duix.ai/duix-app-landing-page/#/home",
-        "title": "Duix",
-        "description": "硅基智能推出的AI数字人生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e84edb3e-f31a-4a24-929c-5a4fdb363c2e.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "1e1afb0a-bef1-45b6-a24d-990299ea9db8"
-    },
-    {
-        "url": "https://trans.xinpianchang.com/",
-        "title": "场辞",
-        "description": "新片场推出的AI视频字幕制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4ccb578-3d72-4a93-9cb4-e16661ad6828.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c6aba157-0112-4d0e-8acb-aac684913c4f"
-    },
-    {
-        "url": "https://www.yiqijian.com/",
-        "title": "一起剪",
-        "description": "AI短视频创作平台，图文一键成片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9c7463bf-a485-43c4-88d8-55682a1c5fdb.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "e71cee27-317e-43fb-9723-bfa4ac07d50c"
-    },
-    {
-        "url": "https://spikes.studio",
-        "title": "Spikes Studio",
-        "description": "AI自动将长视频切片剪辑为短视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82b0d0b2-0dca-45f6-8e11-cd948dcc0961.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "d3779046-44c3-4d82-9665-f8829ad41785"
-    },
-    {
-        "url": "https://workspace.google.com/products/vids/",
-        "title": "Google Vids",
-        "description": "谷歌推出的AI视频创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aa5df58b-0e11-4482-b34c-df5bc0ce99c1.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "f02c6452-52a4-485d-9156-de8364af777d"
-    },
-    {
-        "url": "https://domoai.app/",
-        "title": "DomoAI",
-        "description": "一键将照片和视频动漫化的AI工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3f20c8c-f954-4dc4-8462-704e32ac75cc.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5c5a75d2-b4cf-4ece-9cac-874aa3a3fa9c"
-    },
-    {
-        "url": "https://gatekeep.ai/",
-        "title": "Gatekeep",
-        "description": "AI教学视频生成工具，可生成数学物理问题解释视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2050ac0b-7220-41fc-9d31-c9fc2e1b4b98.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "2e1a378f-96c8-4dac-a164-f02d5c01280f"
-    },
-    {
-        "url": "https://www.morphstudio.com/",
-        "title": "Morph Studio",
-        "description": "高质量的AI文本到视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b5353c63-bf87-468f-b118-f451ee83e64e.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "4d5101d6-965d-4093-bbf6-3bbc0807fcbd"
-    },
-    {
-        "url": "https://haiper.ai/",
-        "title": "Haiper",
-        "description": "AI视频生成和重绘工具，支持文本/图像转视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2adf9fba-7531-4d43-a73f-eb0f0f4bad38.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "7c51ea02-215b-4a39-be15-1423f81372a1"
-    },
-    {
-        "url": "https://www.showrunner.xyz/",
-        "title": "Showrunner",
-        "description": "AI动画视频剧集生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b13ea54-52b3-403d-b39c-0348692cb38c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "78b1088f-efda-44d0-9fc1-1f73585c1957"
-    },
-    {
-        "url": "https://aigc.zego.im/#/MyHome",
-        "title": "即构数智人",
-        "description": "即构科技推出的AI数字人创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7483e42b-718e-4edc-9651-d3a9d226678c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "cf70d524-623e-4495-b1b0-919bac7efdee"
-    },
-    {
-        "url": "https://www.kuaijianji.com/",
-        "title": "快剪辑",
-        "description": "360旗下的AI视频剪辑工具，AI成片、AI数字人、智能添加字幕、去水印等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/939761b8-2040-49f7-b3b1-a389fc5fb777.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "4c34613c-522f-4bae-949a-4acb11b4a1d9"
-    },
-    {
-        "url": "https://www.chanjing.cc/",
-        "title": "蝉镜",
-        "description": "AI数字人视频生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/33030e95-b250-448d-9684-ac077245b3ba.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "55fb9e89-8ee5-480d-af94-bf3877271f91"
-    },
-    {
-        "url": "https://shanjian.tv/",
-        "title": "闪剪",
-        "description": "AI数字人短视频创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8be5a21d-ab4d-46cd-a62e-06d988d5d992.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "3e9e48e5-b879-4caf-9cd9-f37000f78565"
-    },
-    {
-        "url": "https://wonderdynamics.com/",
-        "title": "Wonder Studio",
-        "description": "AI自动为CG角色制作动画、打光并将其合成到真人场景中",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/840849e5-f563-481f-a505-9593d48b4ad0.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "c5a55b6e-f99c-41dd-9ddb-7448432659e0"
-    },
-    {
-        "url": "https://magicam.ai/",
-        "title": "Magicam",
-        "description": "实时的AI直播/视频换脸工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7afb69c1-e7c8-4841-a180-9913d59480c5.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "022f41dd-05db-40fa-baef-d57af22d9000"
-    },
-    {
-        "url": "https://ltx.studio/",
-        "title": "LTX Studio",
-        "description": "AI电影制作和视频短片生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3c844fd-e1f6-493c-81f6-c88ca3d2efc8.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a3cf8378-3dd6-423a-b4bc-9401c1c08ef8"
-    },
-    {
-        "url": "https://www.clipfly.ai/",
-        "title": "Clipfly",
-        "description": "一站式AI长视频制作和编辑平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/33567e5a-3527-408b-9994-e7f26f5aec35.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "17f4ce61-815c-4b57-ac9e-a0d72741ac06"
-    },
-    {
-        "url": "https://www.captions.ai/",
-        "title": "Captions",
-        "description": "AI驱动的视频剪辑和制作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14519c6b-6e17-4f6c-874d-5f68495a519e.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "027a9af9-2b98-46fb-bf5d-4546b4e8619c"
-    },
-    {
-        "url": "https://capsule.video/",
-        "title": "Capsule",
-        "description": "AI驱动的在线视频剪辑工具，个人和小团队免费",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/17379d49-d948-47bf-956e-dc31905c8346.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "7f76e945-8d6d-44c1-b5d5-09bfb2e0cf3c"
-    },
-    {
-        "url": "https://www.goenhance.ai/",
-        "title": "GoEnhance",
-        "description": "AI视频风格转换和画质增强工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e354dcf-d221-4880-88dc-84c16e117438.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "9e358955-423e-4f09-bc2d-c99c4fed437b"
-    },
-    {
-        "url": "https://invideo.io/",
-        "title": "InVideo AI",
-        "description": "人工智能视频创作和剪辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d7e89b33-f251-4b9a-8027-813ba218b05b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "e92dee74-764b-4366-afe0-ae65c6dc1f4c"
-    },
-    {
-        "url": "https://www.unscreen.com/",
-        "title": "Unscreen",
-        "description": "AI智能视频背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a59aacdd-65f0-462b-bf96-9cf29a5eec7b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a5e00b04-ec81-4dca-821d-9f7f9ececb1f"
-    },
-    {
-        "url": "https://ebsynth.com/",
-        "title": "EbSynth",
-        "description": "AI将真人视频转化为油画风动画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24c645a6-b823-445c-9db6-f827b86bdcfc.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "10b464bd-46ce-4fc4-97bf-fa54e9e0186e"
-    },
-    {
-        "url": "https://app.artflow.ai/",
-        "title": "Artflow",
-        "description": "AI创建生成视频动画",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d15baff3-0cd4-4b55-83c6-5a23e1259db3.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "9916d948-d6b3-48e9-b6fa-fd20ca6ab7cf"
-    },
-    {
-        "url": "https://www.kaiber.ai/superstudio/",
-        "title": "Kaiber",
-        "description": "图片文字转视频的AI引擎",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f6c94859-98df-4508-ae2b-dd7a99d0a8da.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "065b0cf3-88dd-4a8f-9770-d949548565c6"
-    },
-    {
-        "url": "https://www.typeframes.com/",
-        "title": "Typeframes",
-        "description": "AI快速生成高质量的产品介绍视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/df4d2132-5926-4575-968e-76be4dce3b06.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "74e1d4c9-56e0-4dd0-8fc3-03bdc66302ae"
-    },
-    {
-        "url": "https://dreamfaceapp.com/",
-        "title": "DreamFace",
-        "description": "让图片动起来的AI工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83676b12-273e-48aa-a10a-4f3da662fa60.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "0cff29b8-5c8c-44dd-8384-cd5a3a11c57b"
-    },
-    {
-        "url": "https://mootion.com/",
-        "title": "Mootion",
-        "description": "AI原生3D动画创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5481b98f-c48d-4c3f-94d2-8cb6c025be00.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "db9968aa-2779-45d9-b37c-c7be5953d055"
-    },
-    {
-        "url": "https://app.pixverse.ai/",
-        "title": "PixVerse",
-        "description": "爱诗科技推出的AI视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/facde8b6-d54a-41a2-8761-b891690d6e78.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ec73e8d1-fa5c-4bfe-86af-8219e34dff6b"
-    },
-    {
-        "url": "https://www.laihua.com/",
-        "title": "来画",
-        "description": "动画和数字人智能生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9eba0f91-4058-464c-a3c6-4f8296637dba.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "2be9eb5d-a625-4fc7-90d0-0e315eef6ed1"
-    },
-    {
-        "url": "https://weta365.com/conduct",
-        "title": "奇妙元",
-        "description": "AI数字人视频生成平台，由出门问问推出",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53db2e52-eba1-4b8e-b625-3d2139d4c56c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "9d839988-607f-40ad-8fdc-3cc9f57a4755"
-    },
-    {
-        "url": "https://huiyingzimu.com/",
-        "title": "绘影字幕",
-        "description": "一键智能在线自动为视频加字幕",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8b959c84-4fad-4f74-bff0-e0d4bffce172.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "8fa4aa2a-cbe6-446d-b03b-1f132b67e6f7"
-    },
-    {
-        "url": "https://fliki.ai/",
-        "title": "Fliki",
-        "description": "AI文字转视频并配音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5706d48-61c7-46f1-a31f-7550a1e41204.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "2b9f9168-277d-4d17-8752-da00e266e7a7"
-    },
-    {
-        "url": "https://anylang.ai/",
-        "title": "Anylang.ai",
-        "description": "AI视频翻译并保持音色和口型的同步",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7b42178e-29db-4646-a222-49c1faa4c7a7.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "75582388-5a0d-4d24-a7f8-c7c2973dc1db"
-    },
-    {
-        "url": "https://www.aistudios.com/",
-        "title": "DeepBrain",
-        "description": "AI口播视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/018720a0-f5e0-46cd-9a36-76e62587e421.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "02d4f753-81cd-4101-b15e-766dd3c753b6"
-    },
-    {
-        "url": "https://www.synthesia.io/",
-        "title": "Synthesia",
-        "description": "AI视频生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3d0b579-4e07-427a-8fa8-73a44f66a24c.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "1d1b9679-6b90-429e-b407-d89fc9e50d88"
-    },
-    {
-        "url": "https://lumen5.com/",
-        "title": "Lumen5",
-        "description": "AI将博客文章转换成视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/48ad79f7-d5a2-4088-b712-0ec57ca5b546.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "48a9bc7b-7fc7-4143-b0f9-d314fa6d8b81"
-    },
-    {
-        "url": "https://ahrefs.com/writing-tools/paraphrasing-tool",
-        "title": "Rephrase.ai",
-        "description": "AI文字到视频生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dd755332-6c44-4491-93fb-0b40fe53e4b0.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a56ef018-991c-402b-8625-a17ad5aa66c3"
-    },
-    {
-        "url": "https://www.animiz.cn/microvideo/",
-        "title": "万彩微影",
-        "description": "AI智能自动生成动画短视频",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/55cc45c2-8727-43ab-9e8c-df277b2bce7a.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5734aced-e8e7-4e36-af33-d3619ca34687"
-    },
-    {
-        "url": "https://reccloud.cn/",
-        "title": "录咖",
-        "description": "一站式AI音视频总结和转录处理工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4f5db62-3371-45f5-9769-baf5bc33dcfc.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "86ed39c6-da7f-4f5a-8e8b-ebc15b1d6329"
-    },
-    {
-        "url": "https://www.guaishouai.com/",
-        "title": "怪兽AI数字人",
-        "description": "人工智能数字人短视频创作和直播平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/091e1996-ef8f-4c16-b3a3-fe2b3f8f1268.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ac7c7973-407c-4061-bf0a-3a24449866ba"
-    },
-    {
-        "url": "https://teamcut.shanjian.tv/",
-        "title": "团队快剪",
-        "description": "闪剪智能专为团队带货打造的AI视频工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b4b3396-a219-4d99-b18d-b3947acdec27.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "613af843-4bfd-4384-9b6f-3d382e47e063"
-    },
-    {
-        "url": "https://cn.jollytoday.com/",
-        "title": "鬼手剪辑GhostCut",
-        "description": "多功能AI视频二创剪辑和翻译工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1edfde75-a1ab-4492-8360-032dd9d46e08.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "32e57c81-c843-4ffa-9a47-d030685988ee"
-    },
-    {
-        "url": "https://www.mooliv.com/",
-        "title": "模力视频",
-        "description": "AI驱动的视频编辑平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0d420cd9-4222-4573-b6fd-24d3e5a162ba.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "ccf08ceb-ddf2-4ba7-8f35-f62405d0c33a"
-    },
-    {
-        "url": "https://gencraft.com/",
-        "title": "Gencraft",
-        "description": "AI艺术画视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3c29830a-531f-4573-a293-741ee374d245.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "8c5892c1-a1e4-403c-b4b9-eb2714defe1f"
-    },
-    {
-        "url": "https://synthesys.io/",
-        "title": "Synthesys",
-        "description": "AI虚拟人出镜讲解",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f2c20a2-6e10-4f9f-b1a3-17b827652d0b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "1e78ad27-ae45-447e-8e2f-dbaef8830d49"
-    },
-    {
-        "url": "https://www.veed.io/zh-CN/tools/video-background-remover",
-        "title": "Veed Video Background Remover",
-        "description": "Veed推出的AI视频背景移除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51d24356-e7a5-4b22-98cd-245cfbb4ac35.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "a7f2aa59-ce18-40e6-9e3d-6c6fafef7ee0"
-    },
-    {
-        "url": "https://hourone.ai/hour-one-2-0/",
-        "title": "Hour One",
-        "description": "人工智能文字到视频生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1922fa18-1db0-4978-b241-43da07f2d539.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "e5bbe16d-9641-4b74-b8fc-3c033fe30b46"
-    },
-    {
-        "url": "https://bgrem.deelvin.com/zh/remove_video_bg/?params=start",
-        "title": "BgRem",
-        "description": "无水印AI视频背景移除",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6efad195-58aa-41c1-a79f-9bf36bfe20fe.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "4402660f-0477-48f9-9b14-2a498c463823"
-    },
-    {
-        "url": "https://colourlab.ai/",
-        "title": "Colourlab.ai",
-        "description": "好莱坞也在用的AI视频颜色分级工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1a59810-ca93-454e-aad0-d347797da098.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "edb42a3e-6741-4c3f-b11d-556a285c9526"
-    },
-    {
-        "url": "https://www.colossyan.com/",
-        "title": "Colossyan",
-        "description": "AI虚拟人出镜视频生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b781ba3f-87ff-41e9-b87e-ce831e7776dc.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "874bcf60-26be-4dee-88d5-e3bfe097bb5a"
-    },
-    {
-        "url": "https://app.avclabs.com/#/",
-        "title": "AVCLabs",
-        "description": "AI自动移除视频背景",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/63b6b541-6f99-408c-aa48-c7fb929d8d4f.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "88a26caa-95c6-4847-8dc8-dc6879f2ccb1"
-    },
-    {
-        "url": "https://elai.io/features/",
-        "title": "Elai.io",
-        "description": "AI文本到视频生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aefc33ac-22d0-47b9-9839-d897e5cae1b1.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "5b2c2af8-6f7b-4955-9c77-938b1724511c"
-    },
-    {
-        "url": "https://pictory.ai/",
-        "title": "Pictory",
-        "description": "AI视频制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/87e50df2-927f-46a8-877a-03bf2f71866b.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "cf573b16-64b2-4a65-b5a6-96f8b664d44c"
-    },
-    {
-        "url": "https://www.steve.ai/",
-        "title": "SteveAI",
-        "description": "Animaker旗下AI在线视频制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1782767a-02ab-43dd-907c-8fa2dfae82c6.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "711603a4-84f2-49f1-af4a-84b21883521f"
-    },
-    {
-        "url": "https://www.rask.ai/",
-        "title": "Rask",
-        "description": "AI视频本地化解决方案，支持超过130种语言",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c18e0d8-d9ab-4303-a84f-b593b4a71dfe.png",
-        "category": [
-            "视频工具"
-        ],
-        "type": "web",
-        "id": "3e9302b6-510a-4838-b708-befacd16f4f6"
-    },
-    {
-        "url": "https://www.moyin.com",
-        "title": "魔音工坊",
-        "description": "AI配音工具，轻松配出媲美真人的声音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b7dd4497-8b73-468f-9795-b7668cd02ccf.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "1a7c0178-691e-4d61-a7aa-58ad716fe627"
-    },
-    {
-        "url": "https://peiyin.xunfei.cn/?ftype=14",
-        "title": "讯飞智作",
-        "description": "科大讯飞推出的AI转语音和配音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/99ab9d75-94c4-4b96-a30c-d27375d0cde1.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "29498b79-b229-46a7-b9e6-f1599a7236ab"
-    },
-    {
-        "url": "https://www.suno.ai",
-        "title": "Suno",
-        "description": "高质量的AI音乐创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0123c417-d9a0-43a8-a3de-720376dbb799.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9d40ec28-d4a9-45a4-8359-b49dd31dc77f"
-    },
-    {
-        "url": "https://www.haimian.com",
-        "title": "海绵音乐",
-        "description": "字节跳动推出的免费AI音乐创作和发现平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2ceb60a-63f3-4324-a8b5-6f0d72c3170e.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "24118b2e-491c-4eff-b81c-10059f0a7b34"
-    },
-    {
-        "url": "https://www.yinfeng.cn/home",
-        "title": "音疯",
-        "description": "昆仑万维推出的AI音乐创作平台，一键生成原创歌曲",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/48bd6b42-76cf-4403-a47f-a73d6f010e08.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9571c95c-9e8b-47ef-ab68-6e8c533b86f7"
-    },
-    {
-        "url": "https://lang123.top",
-        "title": "琅琅配音",
-        "description": "智能文本转语音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d1facd3d-eb97-407c-b4c2-2874ed46987d.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "f4d02c0c-b16c-40f2-81cc-8bcaf3aa4fcc"
-    },
-    {
-        "url": "https://noiz.ai/landing",
-        "title": "Noiz AI",
-        "description": "AI配音工具，支持文本转语音和声音克隆",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d1ce12c-479f-4ba1-8e7a-fcd22d02a447.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "275be77b-d13c-4ede-a474-714006c1ea51"
-    },
-    {
-        "url": "https://www.minimax.io/audio",
-        "title": "MiniMax Audio",
-        "description": "MiniMax推出的AI语音合成工具，支持声音克隆",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/406e214c-3113-4d52-b84e-3a77ca5cc052.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "1bf607f7-22e4-46ad-b9fc-f86641054457"
-    },
-    {
-        "url": "https://www.mureka.ai",
-        "title": "Mureka",
-        "description": "昆仑万维推出的 AI 音乐商用创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1bd634ef-0b45-4674-bbdb-8f0b5cfad4ac.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "3e59098d-db9c-4adb-ae30-bbb12c14a091"
-    },
-    {
-        "url": "https://www.tianpuyue.cn",
-        "title": "天谱乐",
-        "description": "唱鸭团队推出的首个多模态音乐生成大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7c0002f0-1fe4-4e91-8bf5-57c3c46f274e.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "31deb4c8-8ede-41e3-a2cd-87f49614b57f"
-    },
-    {
-        "url": "https://audioeditor.ximalaya.com",
-        "title": "音剪",
-        "description": "喜马拉雅推出的一站式AI音频创作平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebff3c5e-bd34-47ff-b997-f670b7c58047.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "27841cde-efd9-4d83-a3c3-db9e55d3a9d2"
-    },
-    {
-        "url": "https://www.iflyrec.com/zhuanwenzi.html",
-        "title": "讯飞听见",
-        "description": "科大讯飞推出的在线AI语音转文字工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c00d2d6d-de68-4638-8270-369a50f83f2d.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "2578233e-3c68-436b-9cb7-5bde4f9669cc"
-    },
-    {
-        "url": "https://memo.ac",
-        "title": "MemoAI",
-        "description": "免费的AI语音转文字工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e2abe711-3704-4634-890b-ad577a77dd18.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "d483c612-0568-43cd-b236-1367b224ae71"
-    },
-    {
-        "url": "https://www.reecho.ai",
-        "title": "Reecho睿声",
-        "description": "超拟真的中英文AI语音克隆/生成平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a9b6769-7929-4394-833e-2e797d77ab14.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "215a1296-ca84-439c-a001-dda131f790cb"
-    },
-    {
-        "url": "https://www.udio.com",
-        "title": "Udio",
-        "description": "免费的AI音乐创作工具，每月可生成1200首歌曲",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bc353220-8004-4cc3-b8bb-59200c5c43ad.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "616f9a72-ca30-4daf-9e99-b9308fa4e2c7"
-    },
-    {
-        "url": "https://tianyin.163.com/",
-        "title": "网易天音",
-        "description": "网易推出的一站式AI音乐创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/363171b6-ab43-4079-93a3-0a2a265adfa5.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "974b5533-ae67-485c-a3aa-28dfcfeb7dd7"
-    },
-    {
-        "url": "https://y.qq.com/tme_studio/index.html#/",
-        "title": "TME Studio",
-        "description": "腾讯音乐推出的智能音乐创作助手",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/197da5c5-9e14-4dc3-b92a-70b175a16d66.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "1c6d23c4-3ae4-44b2-a64b-37b1c90782b4"
-    },
-    {
-        "url": "https://lyricsintosong.ai/zh",
-        "title": "Lyrics Into Song AI",
-        "description": "在线AI音乐创作工具，输入歌词创建个性化歌曲",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a8d7c19-e659-406c-b5ec-936130c64ff9.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "fb05cf23-8550-4984-b7c3-bbe8c19ab5fe"
-    },
-    {
-        "url": "https://www.stableaudio.com",
-        "title": "Stable Audio",
-        "description": "Stability AI最新推出的音乐生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5de5214c-453c-47e2-a1b0-293312d412fb.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "bc09fd31-d350-47f4-b17b-20b10fa8d68c"
-    },
-    {
-        "url": "https://texttospeech.im/zh-CN",
-        "title": "TextToSpeech",
-        "description": "完全免费的AI文字转语音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09347be4-f600-47f1-a655-78888327a3ac.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "13f1a26e-dda8-42af-be61-faae28cca532"
-    },
-    {
-        "url": "https://ttsmaker.cn",
-        "title": "TTSMaker",
-        "description": "马克配音（MakVoice）推出的免费AI文字转语音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b7105f23-01de-4df9-a4b3-4664db0519e6.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "6865fd5e-fed6-4fd2-9056-03b0771484f9"
-    },
-    {
-        "url": "https://lovo.ai",
-        "title": "LOVO AI",
-        "description": "AI人声和文本转语音生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3a18677-8535-4dc9-ba2a-2276be632973.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "3de1b8fd-a0bc-457b-a8ba-9de16fc1c2b2"
-    },
-    {
-        "url": "https://uberduck.ai",
-        "title": "Uberduck",
-        "description": "开源的AI语音生成社区，5000多种不同的声音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd2d656a-dead-4bb9-9f25-f0751e874b36.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "20005394-1389-43fa-bd46-73a3b49b5963"
-    },
-    {
-        "url": "https://try.elevenlabs.io",
-        "title": "ElevenLabs",
-        "description": "AI文本转语音，支持包含中文在内的28种语言",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a07b0002-ab77-4b1c-8e04-223d943fb28b.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9018ab4b-1bac-4221-b3d1-8da6b832ba94"
-    },
-    {
-        "url": "https://sonauto.ai",
-        "title": "Sonauto",
-        "description": "免费的AI音乐生成和歌曲创作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/507e54cd-8860-4162-b173-5875663da22c.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "bc634edf-30b7-43a6-9c73-e32d3399358f"
-    },
-    {
-        "url": "https://www.tiangong.cn/music",
-        "title": "天工SkyMusic",
-        "description": "昆仑万维发布的国内首个AI音乐生成大模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e25f72a4-85d1-4778-b1f0-ce142a90a49c.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "285b41de-c794-4230-a5ef-74a7184ecc2d"
-    },
-    {
-        "url": "https://dubbing.tech",
-        "title": "大饼AI变声",
-        "description": "免费专业的AI变声软件，一键实时语音变声",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38ec0d9e-70b2-40e4-927d-aa61047e00d9.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "dd3231a8-3913-4285-b996-f09a2aa9fffb"
-    },
-    {
-        "url": "https://product.supertone.ai/shift",
-        "title": "Supertone Shift",
-        "description": "AI驱动的实时语音变换软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5af526ae-147d-40cc-b925-35a2a110ffc2.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9637648e-d6f7-4100-bade-44ed15581297"
-    },
-    {
-        "url": "https://www.riffusion.com/",
-        "title": "Riffusion",
-        "description": "AI生成不同风格的音乐，免费开源",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f50da0e1-4cf3-4411-b036-9d60a357c670.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "fb700747-7942-48bb-bd46-72e7c0aff3fc"
-    },
-    {
-        "url": "https://podcast.adobe.com/",
-        "title": "Adobe Podcast",
-        "description": "Adobe推出的在线AI音频录制和编辑工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96bfb314-9f7b-48cb-b235-8b59605bcbba.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "c9b285b3-9708-4497-ba6b-158349a866ef"
-    },
-    {
-        "url": "https://xstudio.music.163.com",
-        "title": "网易云音乐·X Studio",
-        "description": "网易云音乐与小冰智能联合推出的免费AI歌手音乐创作软件",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b15804fc-ee13-4fc2-a6c2-cb41a5a1ef41.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9c2912a8-f0df-4217-8ea8-0b5b71911c61"
-    },
-    {
-        "url": "https://www.icnpy.com",
-        "title": "刺鸟配音",
-        "description": "刺鸟科技推出的专业AI配音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5a988f63-e2fa-4646-bff9-bddeed0305b7.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "fb3be465-8b23-49a7-8e8e-890a99b5fe3b"
-    },
-    {
-        "url": "https://www.wondercraft.ai",
-        "title": "Wondercraft",
-        "description": "AI音频内容生成工具，可创建播客有声书等",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4d1304f9-93ca-4d97-8d5c-b213245b9e68.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "82ab6384-7977-4d72-b3dd-cf123f506977"
-    },
-    {
-        "url": "https://fryderyk.ai",
-        "title": "Fryderyk",
-        "description": "AI音乐创作工具，集成了多种乐器声音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83913f6d-d9a3-4b5e-a7e0-606f25aa9bc0.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "22904a71-8cc9-4fec-a399-a87b03ae91bf"
-    },
-    {
-        "url": "https://voicenotes.com",
-        "title": "Voicenotes",
-        "description": "AI驱动的语音笔记工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e89a65ff-7910-4a12-9212-ae08c53449b2.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "3d4546c4-6fcb-472f-8f1e-5f3e554819d1"
-    },
-    {
-        "url": "https://www.optimizerai.xyz",
-        "title": "OptimizerAI",
-        "description": "AI声音效果生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b3248f8-0c7c-43e5-b828-5aa3ef097539.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "32fc10d4-0995-4d48-9fc1-02f6cb1c972e"
-    },
-    {
-        "url": "https://ace-studio.timedomain.cn",
-        "title": "ACE Studio",
-        "description": "AI歌声合成工具，输入歌词与旋律即可生成宛如真人的歌声",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/956f0b48-609d-43ef-aa7d-8431fe581188.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "da15e888-247e-46f8-b0ee-47a9156b1acb"
-    },
-    {
-        "url": "https://aigc.unisound.com",
-        "title": "蓝藻AI",
-        "description": "云知声旗下的AI配音和声音克隆平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c7d77ac-a2a7-40e7-81a6-75a677244aed.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "000eccaf-6229-495d-b02c-b735ef27b279"
-    },
-    {
-        "url": "https://deepgram.partnerlinks.io",
-        "title": "Deepgram",
-        "description": "快速低成本的AI语音文本互转API平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/483c4018-6fb7-4921-a4f6-d2877875f700.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "f0c07120-d26b-4394-9855-be6046c9179d"
-    },
-    {
-        "url": "https://audiobox.metademolab.com",
-        "title": "Audiobox",
-        "description": "Meta推出的免费开源的AI语音和声音生成模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e2cb9ff8-b8b1-4ac3-8299-a513612b7d4b.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "cc757637-c8ee-4c74-b00f-4f700cd2f801"
-    },
-    {
-        "url": "https://www.resemble.ai/",
-        "title": "RESEMBLE.AI",
-        "description": "AI人声生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d7159ae-d016-4479-ae66-a9f5ece65e2b.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "b8a1bd6f-0e7a-4b58-aa67-7b4740f49b88"
-    },
-    {
-        "url": "https://www.ibm.com/cloud/watson-text-to-speech",
-        "title": "IBM Watson文字转语音",
-        "description": "IBM Watson文字转语音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/121eb807-8281-4c65-9ee8-67099c84b799.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "244b3e8b-b402-461b-809b-4032dcce619d"
-    },
-    {
-        "url": "https://fakeyou.com/",
-        "title": "FakeYou",
-        "description": "Deep Fake文本转语音",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2bbe5bd9-db06-42f3-ad7d-14feebb1c7bf.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "a549f7aa-b011-4440-8f27-c36c4181859a"
-    },
-    {
-        "url": "https://bgmcat.com/home",
-        "title": "BGM猫",
-        "description": "灵动音科技推出的AI智能生成BGM音乐",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2a11138-fc71-4b9e-ace0-48af2ad779bd.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "db9e07fa-ffe3-46ea-b106-3f1982bd999a"
-    },
-    {
-        "url": "https://www.kzzimu.com",
-        "title": "快转字幕",
-        "description": "AI语音视频转文字和字幕的工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2a7a9d28-a5ad-4d7f-b496-f507825de6e9.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "948cb506-a994-4dd9-af0e-1c7fb9acb516"
-    },
-    {
-        "url": "https://yueyin.zhipianbang.com",
-        "title": "悦音配音",
-        "description": "AI智能在线配音语音合成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9510f56f-a84c-4c2b-a3a8-bd6256117612.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "9359e0bf-124c-470a-a191-4f98df048e67"
-    },
-    {
-        "url": "https://www.soundbug.com",
-        "title": "音虫",
-        "description": "内置AI音乐编曲的音乐制作工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c03602d5-6815-4963-ae73-5d735a5d8185.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "59a65575-6724-48e8-8ca8-fc653245a988"
-    },
-    {
-        "url": "https://mubert.com/",
-        "title": "Mubert",
-        "description": "AI BGM背景音乐生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a680304e-ea78-4247-b2d0-0f4e3c15f1b4.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "0f24243d-2cd5-4d61-b6c9-75f340d69c18"
-    },
-    {
-        "url": "https://www.beatoven.ai/",
-        "title": "beatoven.ai",
-        "description": "免版税AI音乐创建平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d29c0eb1-33d8-47c0-a268-79e232eaec81.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "c3379006-3df9-4e4e-9e01-7d6b84782570"
-    },
-    {
-        "url": "https://beatbot.fm",
-        "title": "BeatBot",
-        "description": "输入文本提示快速生成歌曲和音乐",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a348ec19-bc5e-47bb-8daf-48aaed9f4f5a.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "98625846-fa19-47fe-9a12-aa12fd750e34"
-    },
-    {
-        "url": "https://audo.ai/",
-        "title": "Audo Studio",
-        "description": "AI音频清洗工具（噪音消除、声音平衡、音量调节）",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/351f27f0-65cb-439d-9f25-f7a2a575ea76.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "372be2da-4d58-4c40-b88d-16822a63465b"
-    },
-    {
-        "url": "https://www.naturalreaders.com/",
-        "title": "NaturalReader",
-        "description": "AI文本转语音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7067dad5-0733-45f4-b9b0-6e7afdd15a84.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "28ba6b5b-f3d4-4761-aa1b-fffd99466f24"
-    },
-    {
-        "url": "https://www.assemblyai.com/",
-        "title": "AssemblyAI",
-        "description": "转录和理解语音的AI模型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efc44f7b-7b31-46dd-9525-c867b5992b84.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "35842524-b563-4c77-84b4-729a97d712ed"
-    },
-    {
-        "url": "https://www.lalal.ai/",
-        "title": "LALAL.AI",
-        "description": "AI人声乐器分离和提取",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/70fa1136-f5ef-4b36-b807-2296d77328d7.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "7b4507f0-20f9-485c-a59e-4fed6c14c5e1"
-    },
-    {
-        "url": "https://krisp.ai/",
-        "title": "Krisp",
-        "description": "AI噪音消除工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1492b2a1-a012-4d53-869a-6b26e5fd87c1.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "69cbd751-f7ad-4841-b8a3-22a62436d49a"
-    },
-    {
-        "url": "https://play.ht/",
-        "title": "Play.ht",
-        "description": "超真实在线AI语音生成",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e8ed80d0-794d-4126-b734-edf936fe0eec.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "29da4ed0-abd4-4b04-bcc4-5b77c4605e88"
-    },
-    {
-        "url": "https://murf.ai/",
-        "title": "Murf AI",
-        "description": "AI文本转语音生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ecf2fa4b-fbe9-405b-b6d6-3caee36ec20a.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "a4304e44-b2af-435e-b24c-7a8de3307f0e"
-    },
-    {
-        "url": "https://www.lemonaide.ai",
-        "title": "Lemonaid",
-        "description": "AI音乐生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c8d1783-0d9d-4c06-8ed4-7e15c47eef10.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "756a889c-66c6-42d8-b630-e621d77a0e3e"
-    },
-    {
-        "url": "https://soundraw.io/",
-        "title": "Soundraw",
-        "description": "AI音乐生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4b05daaf-e998-448f-bcaf-568b6d43d787.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "06a7c6f5-04bd-49da-922c-53342686b39f"
-    },
-    {
-        "url": "https://boomy.com/",
-        "title": "Boomy",
-        "description": "AI快速生成原创音乐的平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b57d6e8-9dcb-406c-87f8-2f8d95d8a208.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "afa44257-2769-4702-9c07-24722278d765"
-    },
-    {
-        "url": "https://typecast.ai/",
-        "title": "Typecast",
-        "description": "在线AI文字转语音生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ec8f1629-e60d-441f-b071-1af7de599a23.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "33d675d0-a971-4835-81a0-e31b0ee43267"
-    },
-    {
-        "url": "https://www.veed.io/tools/text-to-speech-video/ai-voice-generator",
-        "title": "Veed AI Voice Generator",
-        "description": "Veed推出的AI语音生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25ebdc3e-af7e-42ca-9db0-9608626e5d58.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "a95377c8-de16-4556-a1bd-dcfd1906767c"
-    },
-    {
-        "url": "https://clipchamp.com/zh-hans/features/ai-voice-over-generator/",
-        "title": "Clipchamp AI旁白生成器",
-        "description": "Clipchamp的文字转语音生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27496742-6f7f-4f37-8f50-9bc8e8010afa.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "3d458787-b5d7-4b86-af10-f23a928fdca3"
-    },
-    {
-        "url": "https://themetavoice.xyz/",
-        "title": "MetaVoice",
-        "description": "AI实时变声工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7e62024a-f4d7-41c5-ac43-64960bbe07f7.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "faf5a7a0-724c-4243-9dde-199efa6ec4e2"
-    },
-    {
-        "url": "https://speechify.com/zh-hans/",
-        "title": "Speechify",
-        "description": "超2000万人都在用的文字转语音朗读器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8f61d052-a270-451c-b665-047a1093737a.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "fc61d575-732e-489f-bedc-99e2f82143d2"
-    },
-    {
-        "url": "https://voicemaker.in/",
-        "title": "Voicemaker",
-        "description": "AI文本到语音生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c15fd280-b708-4fcb-b9d9-79f74b6f2356.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "fdd3095a-0594-480c-b0b1-26d730f01c5b"
-    },
-    {
-        "url": "https://voice.ai/",
-        "title": "Voice.ai",
-        "description": "实时AI变声工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83b9b616-5d45-4f34-b630-b27898c1324b.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "85fd5ea5-d86c-4b2f-aa23-eebfd9afcb02"
-    },
-    {
-        "url": "https://www.listnr.tech/",
-        "title": "Listnr",
-        "description": "AI文本到语音生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cb882bf8-592a-49a5-b85f-402f90c1af87.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "d78e1f13-330a-4bdc-b5e5-09116f574147"
-    },
-    {
-        "url": "https://www.voicemod.net/ai-voices/",
-        "title": "Voicemod",
-        "description": "AI变声工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7b05196b-1869-40d1-8d1f-03e80b683ec7.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "2bcdf6f1-eb05-479e-82f7-25add892e396"
-    },
-    {
-        "url": "https://wellsaidlabs.com/",
-        "title": "WellSaid Labs",
-        "description": "AI文本转语音工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/eb64cc73-54f2-43c7-93d9-d093e03bcda1.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "b4eb11de-d527-42ea-9209-69a8111e3590"
-    },
-    {
-        "url": "https://www.notta.ai/en",
-        "title": "Notta",
-        "description": "AI在线将语音转换成文字",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe880cad-fb4e-4486-a70f-d6f7fa797ad6.png",
-        "category": [
-            "音频工具"
-        ],
-        "type": "web",
-        "id": "23e147bf-4117-46f9-8e35-0d8b9fe646b9"
-    },
-    {
-        "url": "https://logolivery.ai",
-        "title": "LogoliveryAI",
-        "description": "免费的AI Logo生成器，提供SVG矢量格式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9210cdd5-6943-491f-815f-3841aea7bace.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "5c10500b-83ed-4057-bf5d-23a730ba2e18",
-        "type": "web"
-    },
-    {
-        "url": "https://motiff.com",
-        "title": "Motiff 妙多",
-        "description": "猿辅导旗下推出的AI界面设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b969971-367e-4146-9672-1fe3876b1248.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "9f209582-8635-4285-b951-a05f0e905ddf",
-        "type": "web"
-    },
-    {
-        "url": "https://www.pimento.design",
-        "title": "Pimento",
-        "description": "人工智能驱动的设计创意和视觉参考平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/77247ee2-066b-4ef9-a122-340c6da8e34d.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "c8d5b2d4-e6bb-4486-9834-d9db613a57ef",
-        "type": "web"
-    },
-    {
-        "url": "https://logodiffusion.com",
-        "title": "Logo Diffusion",
-        "description": "AI驱动的Logo和标志生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/612f17fe-ac13-4a8d-bb12-5aef7dc56f80.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "94b81fac-0789-4be6-9506-7989ce5339f3",
-        "type": "web"
-    },
-    {
-        "url": "https://www.realibox.com/product/ai",
-        "title": "Realibox AI",
-        "description": "AI免费将草图/模型生成3D渲染图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f7e25943-ec94-4ba4-965f-39260a5ec2e6.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "2ca0ea33-8bb9-4a05-9971-e8b9ab4b5d15",
-        "type": "web"
-    },
-    {
-        "url": "https://vectorizer.ai",
-        "title": "Vectorizer.AI",
-        "description": "AI一键将位图转换为矢量图片",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0e13ec0-5317-448c-9d40-e3e021e46c2a.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "2cc3a423-2b36-41c0-9347-ff10e24eae14",
-        "type": "web"
-    },
-    {
-        "url": "https://www.modaiyun.com/mdy/ai",
-        "title": "模袋云AI",
-        "description": "建筑AI创作平台，专注于大型建筑、小型住宅、室内设计、景观的出图和AI模型训练",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8005249f-830a-4c6c-8b82-404581c0594b.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "b8c289fb-6308-44b2-99e1-a5d939871c76",
-        "type": "web"
-    },
-    {
-        "url": "https://www.vizcom.ai/",
-        "title": "Vizcom",
-        "description": "AI渲染转化手绘图为产品设计图",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5dec9b7d-7d4a-40ee-ba06-54414fa8ac40.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "88beaf46-76c5-417c-ac55-8ffb22347c85",
-        "type": "web"
-    },
-    {
-        "url": "https://www.dora.run/ai",
-        "title": "Dora AI",
-        "description": "AI在线生成精美3D动画的网站",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8dfba7a7-dc0e-4f57-9ed7-9bd9b5d7c8b8.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "ffc73a48-20e8-403b-8f7a-81864bab24de",
-        "type": "web"
-    },
-    {
-        "url": "https://designs.ai/",
-        "title": "Designs.ai",
-        "description": "AI设计工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4edf0fc6-2663-447a-bb66-f879e4b9555d.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "47359b1a-c504-40fe-979b-559b5fb1947d",
-        "type": "web"
-    },
-    {
-        "url": "https://www.usegalileo.ai/",
-        "title": "Galileo AI",
-        "description": "AI高保真原型设计",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f91c4c5d-f918-4038-9d0a-3af37b788c1b.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "e8ea717e-c946-48e5-a1c7-4e98d6593d54",
-        "type": "web"
-    },
-    {
-        "url": "https://spline.design/ai",
-        "title": "Spline AI",
-        "description": "Spline推出的AI生成3D物体、动画、材质",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff87ee1b-6258-4a36-aac3-f5ea341bc58f.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "b735e75c-64fe-4966-b751-39de84dd8673",
-        "type": "web"
-    },
-    {
-        "url": "https://hihaibao.com",
-        "title": "千图设计室AI海报",
-        "description": "免费批量生成在线可编辑的AI海报工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e7f0e95e-5188-4dd5-845d-b19fda5ffdeb.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "8aa452c8-1b9b-4315-9b7a-8f8723f4335f",
-        "type": "web"
-    },
-    {
-        "url": "https://www.illostration.com/",
-        "title": "illostrationAI",
-        "description": "AI插画生成，low poly、3D、矢量、logo、像素风、皮克斯等风格",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6fef959-e7ce-4c78-879c-9fe9ac11fdb4.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "7373e997-9636-47ec-82f9-3bfabfae6204",
-        "type": "web"
-    },
-    {
-        "url": "https://uizard.io/ai-design/",
-        "title": "Uizard",
-        "description": "AI网页、App和UI设计，快速生成应用和网站原型",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1fc0619-ed06-4472-8bad-73c979f9248c.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "8ff0f0b5-07da-4cc6-a7bc-8804ba075b44",
-        "type": "web"
-    },
-    {
-        "url": "https://lumalabs.ai/",
-        "title": "Luma AI",
-        "description": "AI 3D捕捉、建模和渲染",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/64c9a543-e511-4f9c-9e38-e64facb453fc.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "36c5e282-2964-4160-a8d7-eeca6b63e5bf",
-        "type": "web"
-    },
-    {
-        "url": "https://www.nolibox.com/introduction",
-        "title": "图宇宙",
-        "description": "高品质AI智能设计平台",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/760f3987-d71c-4c8b-b25c-88f16057ed90.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "70c0a0b4-0ed1-426d-8ad0-88b15b681af6",
-        "type": "web"
-    },
-    {
-        "url": "https://kebuxi.datasink.sensorsdata.cn/r/dF",
-        "title": "Fabrie AI",
-        "description": "在线白板协作平台Fabrie推出的AI设计助手，支持多种渲染模式",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/99aa6d14-9750-40ee-9f5a-b2c36abe8996.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "3aa959e5-63db-46df-a95f-56c41850d15d",
-        "type": "web"
-    },
-    {
-        "url": "https://withpoly.com/browse/textures",
-        "title": "Poly",
-        "description": "AI生成3D材质",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/28b4cffe-50a7-4f09-bcd6-3d269b308cda.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "73d76ae1-55c3-4ae0-abdf-92c1d0aa09c3",
-        "type": "web"
-    },
-    {
-        "url": "https://illustroke.com/",
-        "title": "Illustroke",
-        "description": "AI SVG矢量插画生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f932a9e-167c-42e3-bbaa-c90aa9e3b8fb.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "358f08ab-0b2e-451f-8a23-7be30e969a06",
-        "type": "web"
-    },
-    {
-        "url": "https://colors.eva.design/",
-        "title": "Eva Design System",
-        "description": "基于深度学习的色彩生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53012d16-35f3-4c75-8697-2c41fa71d4e3.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "50bdf17d-dee8-4ada-802b-cc27a7f66f6f",
-        "type": "web"
-    },
-    {
-        "url": "https://brandmark.io/color-wheel/",
-        "title": "Color Wheel",
-        "description": "AI灰度logo或插画上色工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4922f424-2baa-4395-a74c-007da04d14b0.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "37d0facd-5033-47e8-bca7-7f830ad06cd8",
-        "type": "web"
-    },
-    {
-        "url": "https://huemint.com/",
-        "title": "Huemint",
-        "description": "AI调色生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/810a54f5-303b-45a4-b06a-67b7fd66e754.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "1b635ccc-9e34-40c2-84d9-2c163eeb3934",
-        "type": "web"
-    },
-    {
-        "url": "https://www.obviously.ai/",
-        "title": "ColorMagic",
-        "description": "AI调色板生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cca4be73-c13c-4bef-b70a-1f5320b3cfa4.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "7cd4bd5e-0108-4679-8da8-5ba125f1277f",
-        "type": "web"
-    },
-    {
-        "url": "https://logomaster.ai/",
-        "title": "Logomaster.ai",
-        "description": "AI Logo生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8db7439-311a-4664-870f-0ccbf453b38c.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "d12958d9-35a2-4e5c-949d-434f8353acfd",
-        "type": "web"
-    },
-    {
-        "url": "https://magician.design/",
-        "title": "Magician",
-        "description": "Figma插件，AI生成图标、图片和UX文案",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ced40a9-1a43-4fd1-b0ba-6f0da03ec5df.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "457f4519-1bf8-482d-97b6-29d95da89e5b",
-        "type": "web"
-    },
-    {
-        "url": "https://appicons.ai/",
-        "title": "Appicons AI",
-        "description": "AI生成精美App图标",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c0efc05e-a569-4d20-8517-aa9eedd83d2a.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "85f69aa2-623e-4022-aa71-ad74a586bc9b",
-        "type": "web"
-    },
-    {
-        "url": "https://www.iconifyai.com/",
-        "title": "IconifyAI",
-        "description": "AI App图标生成器",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/71cde335-b43d-49ae-8d4e-3ad42337f2ed.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "9e60ba85-fee0-4955-bc6b-1ea174661b6f",
-        "type": "web"
-    },
-    {
-        "url": "https://www.khroma.co/",
-        "title": "Khroma",
-        "description": "AI调色盘生成工具",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20d664f2-1502-4f2d-aab0-7e2ee96dd1fe.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "d04b1630-71e8-469e-b125-34913bc923ef",
-        "type": "web"
-    },
-    {
-        "url": "https://jsai.cc/ai/create",
-        "title": "即时AI",
-        "description": "即时设计推出的由文本描述生成可编辑的原型设计稿",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f781f121-206d-4ea9-90b8-762089e3c489.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "1f4e55eb-3efd-4c96-b6f5-08c75b501d1f",
-        "type": "web"
-    },
-    {
-        "url": "https://www.getalpaca.io",
-        "title": "Alpaca",
-        "description": "将生成式AI集成到Photoshop图像设计中",
-        "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb6f0a41-37c9-4d77-9a11-2caa5a900c03.png",
-        "category": [
-            "设计工具"
-        ],
-        "id": "294c5806-6ed8-4e8f-91cb-572dfb839f0e",
-        "type": "web"
-    },
-    {
-        "url": "https://www.aurcue.com",
-        "description": "AI个人美学助手，根据一张照片生成个人色彩、穿搭、发型和眼镜建议",
-        "image": "https://www.aurcue.com/brand/logo-h-transparent.png",
-        "category": [
-            "图像工具",
-            "设计工具"
-        ],
-        "id": "db99d6a1-94cd-4fd5-b894-9953dfd25b9b",
-        "title": "Aurcue",
-        "type": "web"
-    }
+  {
+    "url": "https://www.doubao.com/chat",
+    "description": "字节跳动推出的免费AI智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a371b2b7-d354-45c7-9caf-46bb38991fd4.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "2c4b2fed-dc11-4296-8c3a-c957dbd95c5a",
+    "title": "豆包",
+    "type": "web"
+  },
+  {
+    "url": "https://xinghuo.xfyun.cn/desk",
+    "description": "科大讯飞推出的AI智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/34b8c8d1-7514-477a-9e00-05926a9c081d.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "80e8d1b9-420c-4ad8-a6ab-32adfe82a15b",
+    "title": "讯飞星火",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.openai.com",
+    "description": "OpenAI旗下AI对话工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3d2c0c8a-65a4-4ae8-b71b-064fb0dbdec7.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "bb9594ab-be67-481b-a4a4-f6df2de4274d",
+    "title": "ChatGPT",
+    "type": "web"
+  },
+  {
+    "url": "https://claude.ai",
+    "description": "ChatGPT的最为有力的竞争对手之一",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/745166c5-4bdb-417f-abc5-f414961e630b.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "5ab96b73-3ed3-4fe8-9336-03ba10b75c5f",
+    "title": "Claude",
+    "type": "web"
+  },
+  {
+    "url": "https://gemini.google.com",
+    "description": "Google推出的AI聊天对话机器人Gemini",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/760aa351-febb-40bb-9965-8ff35c6f45ef.webp",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "c61400db-f4ef-4fd0-92c9-25280e22459e",
+    "title": "Gemini",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.deepseek.com/",
+    "description": "幻方量化旗下深度求索推出的开源大模型和聊天助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/598bc1aa-f428-4416-b762-7e176c8b07e8.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "0d066a34-78fa-4d11-b71b-83595b2b2e23",
+    "title": "DeepSeek",
+    "type": "web"
+  },
+  {
+    "url": "https://kimi.moonshot.cn/",
+    "description": "一次搜索可精读500个页面，会推理解析，能深度思考的AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/846650d3-c65c-419c-b475-620a92aee910.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "460497ba-cd82-4edf-963d-60e4040a5497",
+    "title": "Kimi智能助手",
+    "type": "web"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/qianwen",
+    "description": "阿里推出的自研大模型，通情、达义，你的全能AI助手！",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9332782-5542-4a6a-9492-89804dab08a3.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "9e021e8a-3d34-42be-8bee-8a13e9449e8b",
+    "title": "通义千问",
+    "type": "web"
+  },
+  {
+    "url": "https://chatglm.cn",
+    "description": "免费全能的AI助手，支持AI绘画、视频生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a1ba6f5-7237-4063-9279-875497f567ef.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "4870b3c2-c7d6-4640-bde3-6408c6f7b20b",
+    "title": "智谱清言",
+    "type": "web"
+  },
+  {
+    "url": "https://wenxiaobai.paluai.com",
+    "description": "元石科技推出的AI智能助手，支持DeepSeek满血版",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9dc640f6-a8e8-4438-8512-037f919d0b55.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "604fb838-bdce-4012-b7b4-f01716837980",
+    "title": "问小白",
+    "type": "web"
+  },
+  {
+    "url": "https://yuanbao.tencent.com",
+    "description": "腾讯推出的免费AI智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7434aee2-ff85-4286-8016-355c63027d1e.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "ec719dcf-2db5-436d-ac95-69b92609f04e",
+    "title": "腾讯元宝",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.qwen.ai/",
+    "description": "阿里通义推出的 Qwen AI 大模型Web UI界面",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1b5018f4-451a-4cb4-adf4-43516c6796c4.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "a89de616-bf14-4ead-aab6-21236b19e9f0",
+    "title": "Qwen Chat",
+    "type": "web"
+  },
+  {
+    "url": "https://x.ai/grok",
+    "description": "马斯克旗下xAI推出的人工智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/18932599-e115-4369-a154-fbbb5e06db56.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "6164d30d-d38c-430e-a1d5-5160cd04cafd",
+    "title": "Grok",
+    "type": "web"
+  },
+  {
+    "url": "https://poe.com",
+    "description": "问答社区Quora推出的问答机器人工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ca0d486f-d09f-490b-a07a-7b377e265d0a.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "0fd440eb-e6f0-4554-864f-d71c1d0ea288",
+    "title": "Poe",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.minimaxi.com",
+    "description": "MiniMax推出的免费AI智能聊天助理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1dc09d69-05dd-4d0b-b009-0562b2eb797c.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "4124ecd0-3563-4aee-a621-b33a6867bf50",
+    "title": "MiniMax",
+    "type": "web"
+  },
+  {
+    "url": "https://xiaoyi.huawei.com/chat",
+    "description": "华为旗下小艺AI助手网页端，已接入DeepSeek-R1",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4d36ca7-6f12-41df-b151-69562d498c79.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "ae24707a-a1f0-4903-aeed-140a01ff05d1",
+    "title": "华为小艺",
+    "type": "web"
+  },
+  {
+    "url": "https://yiyan.baidu.com",
+    "description": "百度推出的基于文心大模型的AI对话互动工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80223edf-dce6-4fda-aa7b-200593085613.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "7e49bbd9-3ca4-461c-9d85-bbd8c752b4f0",
+    "title": "文心一言",
+    "type": "web"
+  },
+  {
+    "url": "https://yuewen.cn/chats/new",
+    "description": "阶跃星辰推出的支持多模态的AI聊天机器人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a8ffdc0a-ac92-4434-b54f-64f53fc07df5.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "4d1d9ecb-49fc-45a9-b43b-9f7cd0b1d46a",
+    "title": "阶跃AI",
+    "type": "web"
+  },
+  {
+    "url": "https://ying.baichuan-ai.com/chat",
+    "description": "百川智能推出的免费AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d3030893-2b4d-4b3c-9bfa-d2586a1053af.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "d3cbd8f7-6e22-443a-87cd-b8c3c53712f0",
+    "title": "百小应",
+    "type": "web"
+  },
+  {
+    "url": "https://www.tiangong.cn",
+    "description": "昆仑万维推出的AI智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7df147f4-f027-48e6-8a6b-7e6dcd150a27.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "214ea34b-2463-4fb7-8b9d-5367462745e3",
+    "title": "天工AI",
+    "type": "web"
+  },
+  {
+    "url": "https://copilot.microsoft.com/",
+    "description": "微软推出的网页版Copilot助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/751ba916-b264-41ba-b2b0-356994c1181d.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "7f658af1-4626-4fb1-a839-a7843b95c2d1",
+    "title": "Copilot",
+    "type": "web"
+  },
+  {
+    "url": "https://character.ai",
+    "description": "创建虚拟角色并与其对话",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c433de76-0f95-4ba9-8c5e-28226f76217d.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "22497784-8a3e-4900-be21-ab0c22945c9a",
+    "title": "Character.AI",
+    "type": "web"
+  },
+  {
+    "url": "https://matter.ai/",
+    "description": "罗永浩旗下 Jarvis 项目推出的 AI 智能助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/240bd64e-5170-46a1-bcc8-8148164bce97.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "aef173bb-6c01-4e48-bcd0-4a969ce5fe8b",
+    "title": "J1 Assistant",
+    "type": "web"
+  },
+  {
+    "url": "https://www.meta.ai",
+    "description": "Meta推出的免费AI聊天助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ccea1c6e-8824-4d98-b9f5-bc9e7eace7dc.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "7fa7e017-1f63-4b34-a559-ea9d923d5a55",
+    "title": "Meta AI助手",
+    "type": "web"
+  },
+  {
+    "url": "https://www.seeles.ai",
+    "description": "Seele公司推出的「AI+3D」情感陪伴产品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21b171ec-5f4d-49c5-a532-7e51bd11ca49.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "6a9e0536-5505-47ad-a760-398bd4009b2d",
+    "title": "Koko AI",
+    "type": "web"
+  },
+  {
+    "url": "https://beta.ohai.bot/discover",
+    "description": "月之暗面旗下推出的AI角色扮演虚拟陪伴应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/272aa863-0d38-4eea-b71e-7d748f3c87ad.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "2c2f4e6e-ba01-4d8f-a561-bc11868499c0",
+    "title": "Ohai",
+    "type": "web"
+  },
+  {
+    "url": "https://www.me.bot",
+    "description": "心识宇宙推出的个性化AI伴侣产品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c1e71275-853d-429e-9314-662c3fccef18.webp",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "40cde9be-aaab-4fe8-bd44-b2972b20982e",
+    "title": "Me.bot",
+    "type": "web"
+  },
+  {
+    "url": "https://www.sayloai.com",
+    "description": "AI驱动的故事角色扮演游戏应用，沉浸式的剧本互动体验",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef573be4-e8b5-458d-b5ee-d74fd292c15b.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "b860fa86-eb33-4698-a2b1-5136c6327584",
+    "title": "Saylo",
+    "type": "web"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/xingchen",
+    "description": "用AI定制属于你自己的IP角色",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfd40d27-0624-406b-8161-23f858fa0eff.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "1986a8f7-25cb-4f16-8f32-a1e8c95e8067",
+    "title": "通义星尘",
+    "type": "web"
+  },
+  {
+    "url": "https://cueme.cn",
+    "description": "夸克推出的AI智能对话助手，支持2万字长文写作",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/98e9daa7-59b2-4fd8-bee3-c123e7959f18.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "9abf440e-3734-43a6-ae86-b116f64ea9df",
+    "title": "CueMe",
+    "type": "web"
+  },
+  {
+    "url": "https://ciyuan.ideaflow.pro",
+    "description": "AI互动内容平台，虚拟角色逗你开心",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d9f2cd95-dc12-41ce-a782-56b24030a8a2.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "0d6fcc26-3eef-468d-a961-caaa1377a99b",
+    "title": "造梦次元",
+    "type": "web"
+  },
+  {
+    "url": "https://www.museland.ai",
+    "description": "沉浸式AI角色扮演产品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7469caf6-e2fe-4a78-91f4-95137adcc09c.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "ef6cddb8-bda1-4df0-94cf-901aeae59fb3",
+    "title": "Museland",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.baidu.com",
+    "description": "百度推出的多场景AI智能体助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f5f22366-0a06-49e7-b44d-eb5701e4b632.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "c9de15a0-fa1d-40a8-9aa1-5337fc701b67",
+    "title": "百度AI助手",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.sensetime.com",
+    "description": "商汤科技推出的类ChatGPT的人工智能大语言模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2c86b1d3-9f0c-4813-a22e-50d6a796929a.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "88ab4f56-8ebe-49eb-bb7a-a8f69897f097",
+    "title": "商量SenseChat",
+    "type": "web"
+  },
+  {
+    "url": "https://wukong.com/tool",
+    "description": "字节跳动推出的免费AI对话助手和个人助理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2523ebe-0dba-4e97-b52a-4d45952025bc.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "a4a8fa70-73a2-4243-9c01-e06d17d14c98",
+    "title": "小悟空",
+    "type": "web"
+  },
+  {
+    "url": "https://taichu-web.ia.ac.cn/#/welcome",
+    "description": "中科院与武智院推出的千亿参数全模态大模型和助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27429ee0-5860-4708-882b-629eb7bcf299.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "cbc713c1-16bb-4f0c-ad20-6cd323fa0ea6",
+    "title": "紫东太初",
+    "type": "web"
+  },
+  {
+    "url": "https://chatwiz.cn/h5/feely",
+    "description": "字节跳动旗下推出的AI虚拟交友聊天平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3cecf927-6c55-4dfc-b99d-db1837c8a6d2.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "d947bdc1-b80f-4ea5-94e0-a5b4cb528430",
+    "title": "小黄蕉",
+    "type": "web"
+  },
+  {
+    "url": "https://maopaoya.com",
+    "description": "阶跃星辰推出的AI聊天机器人和智能体平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da09a219-779c-426c-889c-591b265a68f5.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "0870ec15-09fd-476a-937d-45d5c4ed115f",
+    "title": "冒泡鸭",
+    "type": "web"
+  },
+  {
+    "url": "https://www.cici.com/browser-extension/landing/zh",
+    "description": "豆包国际版，字节跳动面向海外市场推出的AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8943e53-0a8b-4333-8817-6cbe4c18e5a0.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "b6020b8b-7b4e-4b60-a311-c9cb77c00667",
+    "title": "Cici",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.baichuan-ai.com",
+    "description": "百川智能推出的大模型助手，融合了意图理解、信息检索以及强化学习技术",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4e3f8d02-1736-4259-8825-5174b097d83f.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "4aecff56-5fd5-4c42-8489-c454eb703a85",
+    "title": "百川大模型",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.mistral.ai",
+    "description": "Mistral推出的AI对话聊天助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9fe949d3-f581-4f49-b7ee-68d984172387.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "a2536e3f-d452-46e0-b799-87db423a0228",
+    "title": "Le Chat",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.baidu.com/",
+    "description": "百度最新上线的AI搜索对话工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2fa3607d-00b4-4ac3-a1f6-c448ea43a7df.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "13c369ef-d4f4-4e5b-87d1-6bdeda3acf0e",
+    "title": "百度AI伙伴",
+    "type": "web"
+  },
+  {
+    "url": "https://cloud.baidu.com/product/infoflow.html",
+    "description": "百度智能云发布的基于文心一言的AI原生应用和Copilot“超级助理”",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ff54777-f365-4c6c-91af-3aad14e5a8a5.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "a023f697-3a8b-4cda-a15a-e713356fc7b6",
+    "title": "超级助理",
+    "type": "web"
+  },
+  {
+    "url": "https://workspace.dingtalk.com",
+    "description": "钉钉推出的个人版办公应用程序，内置AI智能助手，可进行AI创作、AI对话、AI绘画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9b0e25e5-ee64-48f9-bd82-4c378d9872ae.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "5e0fa227-a23f-45fe-b552-1b721a04a5e8",
+    "title": "钉钉·个人版",
+    "type": "web"
+  },
+  {
+    "url": "https://wanderboat.ai",
+    "description": "硅谷初创公司UTA AI推出的AI旅行助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27df4d9e-2bb0-4754-af7c-a82dee894672.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "98f16948-acee-4fa4-accd-66d444037638",
+    "title": "Wanderboat",
+    "type": "web"
+  },
+  {
+    "url": "https://www.langboat.com/portal/mengzi-gpt",
+    "description": "基于孟子GPT大模型的AI对话机器人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4fe2d25e-2676-4c8f-b580-ae87112b58d5.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "cfce49c2-04b1-4144-9d7f-7667700c1695",
+    "title": "MChat",
+    "type": "web"
+  },
+  {
+    "url": "https://luca-beta.modelbest.cn/",
+    "description": "面壁智能推出的千亿多模态大模型免费智能对话助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cdd79f9a-e2df-40d5-b95b-c085dd19115a.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "03be11be-b0cd-4a3c-800b-2941aa26d5dd",
+    "title": "Luca面壁露卡",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.xverse.cn/xchat/index.html",
+    "description": "元象XVERSE大模型驱动的AI聊天助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a8f27f8-6b5a-4d09-a826-8e772360edca.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "d474c8c4-0d7b-407b-a42c-02c66efbbb2d",
+    "title": "元象XChat",
+    "type": "web"
+  },
+  {
+    "url": "https://www.chitchop.com",
+    "description": "字节旗下面向海外用户推出的免费大模型产品和AI助手工具箱",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e206fa0b-d621-41f7-90fd-16fbfb0e92cf.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "fe47fb10-74b9-4e7f-849e-eb0e2d808bb9",
+    "title": "ChitChop",
+    "type": "web"
+  },
+  {
+    "url": "https://www.modelscope.cn/studios/iic/ModelScopeGPT",
+    "description": "阿里达摩院推出的大小模型协同的智能助手，具备作诗、绘画、视频生成、语音播放等多模态能力",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/316ae173-70e1-4f49-a9c1-7e0bac24e02e.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "8dfbbf9a-cf3f-4b9e-b604-39fb80450e63",
+    "title": "魔搭GPT（ModelScopeGPT）",
+    "type": "web"
+  },
+  {
+    "url": "https://huggingface.co/chat/",
+    "description": "HuggingFace推出的在线聊天机器人，基于Open Assistant模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f310f59f-5c04-4ec8-91f5-a362470942a3.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "edd87ce6-8bc8-4c94-8f30-787ab997ec1a",
+    "title": "HuggingChat",
+    "type": "web"
+  },
+  {
+    "url": "https://tigerbot.com",
+    "description": "虎博科技推出的AI对话聊天机器人，基于TigerBot开源大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1fbae9a7-78be-439f-be9a-5ed917245897.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "f024643b-8280-4d9e-bb62-42b19f331eac",
+    "title": "TigerBot",
+    "type": "web"
+  },
+  {
+    "url": "https://research.stability.ai/chat",
+    "description": "Stability AI 最新推出的免费聊天对话网站",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4545bd70-0ac1-48fc-af61-5d6956678ab6.png",
+    "category": [
+      "聊天助手",
+      "图像工具",
+      "图片插画生成"
+    ],
+    "id": "0c39c6f5-bc44-4902-9a80-b3e65f6f0470",
+    "title": "Stable Chat",
+    "type": "web"
+  },
+  {
+    "url": "https://chat.colossalai.org",
+    "description": "Colossal-AI推出的免费开源版ChatGPT聊天机器人替代品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1047a32-2b8c-4df3-ab83-916eab97e3aa.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "f0d09b5a-db64-4ec3-9d2e-b86f60b463b9",
+    "title": "ColossalChat",
+    "type": "web"
+  },
+  {
+    "url": "https://www.jasper.ai/chat",
+    "description": "Jasper针对内容创作者出品的AI聊天工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51f74926-1609-4245-abbe-8aa2891b24d2.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "0aa4eed9-533e-42f8-bf60-379661b003ab",
+    "title": "Jasper Chat",
+    "type": "web"
+  },
+  {
+    "url": "https://chat-sonic.ai/#",
+    "description": "WriteSonic出品的ChatGPT竞品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b5deaa6c-f4de-4db7-a62d-25f224abc624.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "9d81186b-68bf-46a8-b172-c2340e46f97e",
+    "title": "ChatSonic",
+    "type": "web"
+  },
+  {
+    "url": "https://replika.ai/",
+    "description": "AI对话陪伴工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4a4073a-248d-4f4d-a0c0-c28f7b9b459d.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "f196398d-0866-4ff9-ac28-06c440d7f7a1",
+    "title": "Replika",
+    "type": "web"
+  },
+  {
+    "url": "https://pi.ai/talk",
+    "description": "DeepMind联创新公司推出的AI聊天机器人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96fd39c8-fdf3-4dbe-8bf5-c89dba680200.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "f12875a5-cb95-406e-a3ee-a3b5e7f6f774",
+    "title": "Pi",
+    "type": "web"
+  },
+  {
+    "url": "https://ai.360.com",
+    "description": "360搜索最新推出的AI对话聊天机器人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cac87af3-9caa-4133-b29a-c4644840ad27.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "2fd0b362-e5ac-4645-9550-d75ea0a0966a",
+    "title": "360智脑",
+    "type": "web"
+  },
+  {
+    "url": "https://xiezuocat.com",
+    "description": "秘塔写作猫推出的AI对话聊天工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f281fe07-ea60-4ded-82a8-8a630c7b3576.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "48c322e9-6aa3-40dd-b016-d6dbea1edca0",
+    "title": "对话写作猫",
+    "type": "web"
+  },
+  {
+    "url": "https://hailuoai.com",
+    "title": "海螺AI",
+    "description": "MiniMax推出的AI对话助理，已免费开放",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/342d526d-710b-4a24-ae96-7892f755b304.png?v=3",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "e329c605-b024-4f87-b855-cc856c68b594",
+    "type": "web"
+  },
+  {
+    "url": "https://studyarena.com",
+    "title": "StudyArena",
+    "description": "免费比较同一学习问题的三个匿名 AI 回答，投票后揭示模型名称",
+    "image": "https://studyarena.com/icon.png",
+    "category": [
+      "聊天助手"
+    ],
+    "type": "web",
+    "id": "53238464-5572-45a3-ab13-6b340dca8964"
+  },
+  {
+    "url": "https://b.quark.cn/apps/qkhomepage_twofoufeb/routes/model",
+    "title": "夸克AI",
+    "type": "app",
+    "description": "集AI搜索、网盘、文档、创作等功能于一体的应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a49c1167-8598-4071-b10d-47f2f5447b0f.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "3024a58b-7f54-4052-b93b-6427c4ce9ff3"
+  },
+  {
+    "url": "https://iflow.cn",
+    "title": "心流",
+    "type": "web",
+    "description": "阿里旗下推出的AI搜索助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a9968cc4-0843-46c8-bf0b-84548e97fa2a.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "d47eff1f-a605-44f5-8e55-d8374edccb96"
+  },
+  {
+    "url": "https://metaso.cn",
+    "title": "秘塔AI搜索",
+    "type": "web",
+    "description": "最好用的AI搜索工具，没有广告，直达结果",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d97d01e8-43d4-411c-b958-0b363150e626.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "5fc79bbc-c259-4254-a076-70d64729c74c"
+  },
+  {
+    "url": "https://www.perplexity.ai",
+    "title": "Perplexity",
+    "type": "web",
+    "description": "强大的对话式搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a95b7bf-df6f-4559-bc1d-f21bbd0e8622.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "6ae476ee-845e-4afc-af25-c0978b51d8e6"
+  },
+  {
+    "url": "https://chatgpt.com/",
+    "title": "SearchGPT",
+    "type": "web",
+    "description": "OpenAI最新推出的搜索引擎，内测开放",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e110cfe-db43-4a33-9231-0ac62be98266.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "870a2eca-bbf6-456e-b4ce-38cc3ce5c185"
+  },
+  {
+    "url": "https://flowith.net/blank",
+    "title": "Flowith",
+    "type": "web",
+    "description": "节点交互式AI搜索和对话工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8d3fb27-2992-41d4-a135-14dc9d47fcc9.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "5889c9d3-461c-4ef8-b2ee-4c610388d76a"
+  },
+  {
+    "url": "https://www.genspark.ai",
+    "title": "Genspark",
+    "type": "web",
+    "description": "基于智能体的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c8310a4-d38a-4263-877c-90e34e7bbe51.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "46fd5ee6-8647-43dc-925b-93ce867be0ce"
+  },
+  {
+    "url": "https://devv.ai/zh",
+    "title": "Devv",
+    "type": "web",
+    "description": "面向程序员的新一代搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8c50dc5-ef61-4fa9-8e36-217cd2b12add.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "0015bf87-b9b5-49bd-9ac8-0532d49368b2"
+  },
+  {
+    "url": "https://zhida.zhihu.com",
+    "title": "知乎直答",
+    "type": "web",
+    "description": "知乎推出的搜索引擎，直达问题答案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e57659d1-a653-42f4-b5b2-552fc30d1693.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "7d3072aa-89c0-46bb-b048-5b1102ded9b7"
+  },
+  {
+    "url": "https://www.n.cn",
+    "title": "纳米搜索",
+    "type": "web",
+    "description": "360公司推出的AI搜索应用，一切皆可生成视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cffff956-f50e-4a10-9f1a-ff6e7f27ea11.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "4f7cc133-9eb2-4894-aabf-4b4d5ae250f2"
+  },
+  {
+    "url": "https://chat.baidu.com/search",
+    "title": "百度AI探索版",
+    "type": "web",
+    "description": "百度推出的深度搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80e73ff4-61d9-4663-8b50-cdc0ab496714.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "5380338a-3c72-434c-b87b-c5b8087ab4d7"
+  },
+  {
+    "url": "https://felo.ai/search",
+    "title": "Felo",
+    "type": "web",
+    "description": "免费AI智能搜索引擎，支持社交联网搜索和多语种问答结果",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e235ec8b-84a7-4836-a887-e639bf9d2d16.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "dabbf87f-1e56-4889-8567-0f4a6d1d15a1"
+  },
+  {
+    "url": "https://www.aminer.cn/",
+    "title": "AMiner",
+    "type": "web",
+    "description": "智谱AI推出的大模型学术平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/888d330f-bd43-46f8-b34b-32761d2830c9.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "ddbccb3b-0dac-4cb9-8f38-eb50400b8ecb"
+  },
+  {
+    "url": "https://tiangong.cn",
+    "title": "天工AI搜索",
+    "type": "web",
+    "description": "昆仑万维最新推出的结合大模型的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/67adbea4-596a-497c-9d44-41ba69b8cb0b.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "b11d5f76-fa1c-4b98-9af0-89584dee3bff"
+  },
+  {
+    "url": "https://new-front.chatglm.cn/webagent/landing/index.html",
+    "title": "清言插件",
+    "type": "plugin",
+    "description": "智谱推出的浏览器AI插件，支持AutoGLM、站内高级检索",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f5541983-de84-468e-a162-448a057de00d.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "266ff5b5-d052-42bb-bead-2656cbb6eac4"
+  },
+  {
+    "url": "https://dashboard.exa.ai/playground",
+    "title": "Exa AI",
+    "type": "web",
+    "description": "专门为AI模型设计的搜索引擎平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/00ec479a-c92d-4b3d-af74-25fc33c70030.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "d73aa1ab-cab3-4cef-b203-0292e7a6a2ef"
+  },
+  {
+    "url": "https://www.reddo.cloud/search_home",
+    "title": "Reddo",
+    "type": "web",
+    "description": "全球产品信息搜索引擎，能语义化搜索任何公开的产品与公司",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8aebbca5-44bb-4254-b046-ad42ce9166b9.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "93e20943-6bd3-493e-a283-717d7e16a1cb"
+  },
+  {
+    "url": "https://bochaai.com/",
+    "title": "博查AI搜索",
+    "type": "web",
+    "description": "支持多模型的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ba1395c-7ad2-4a3d-a412-f53cf713a159.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "65c373bf-d89a-4b15-9de2-767534846e7b"
+  },
+  {
+    "url": "https://www.lianqiai.cn",
+    "title": "链企AI",
+    "type": "web",
+    "description": "链企智能推出的AI商业搜索工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/754fb726-66f3-43d7-9700-53537f8aa5b0.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "58a7d05d-5484-4004-8702-93448c9d4136"
+  },
+  {
+    "url": "https://ask.xiaoyuzhoufm.com",
+    "title": "问问小宇宙",
+    "type": "web",
+    "description": "小宇宙推出的AI搜索产品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe26175d-0743-4a81-af58-02aeb75143c1.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "11fd8bc2-39af-49ca-895e-3afc7d82be0f"
+  },
+  {
+    "url": "https://dexa.ai",
+    "title": "Dexa AI",
+    "type": "web",
+    "description": "AI播客搜索工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/34043fa0-2d7e-4e91-9c3e-9ee1d2a2cf85.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "950a1df5-1bfa-468d-99ee-a161c9d72e14"
+  },
+  {
+    "url": "https://kaisouai.com/",
+    "title": "开搜AI",
+    "type": "web",
+    "description": "面向大众的免费AI问答搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6163b985-4189-4039-a5e4-776f6ea6334a.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "38a17d62-06f9-4250-ac5a-70467a9bd202"
+  },
+  {
+    "url": "https://www.adot.tech",
+    "title": "Adot",
+    "type": "web",
+    "description": "一个由AI驱动的 Web3 搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8e07f8b-1f9f-4f49-9d1c-a623fdc89498.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "9f05f1d2-68d8-418e-8952-dac21caad7de"
+  },
+  {
+    "url": "https://www.xanswer.com",
+    "title": "XAnswer",
+    "type": "web",
+    "description": "支持生成思维导图的免费AI搜索工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8434476d-a934-4d1a-8def-034283926cbb.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "26c99b5f-584f-4894-8404-2e9f1fa4016d"
+  },
+  {
+    "url": "https://www.alpha-sense.com",
+    "title": "AlphaSense",
+    "type": "web",
+    "description": "专为金融专业人士设计的AI搜索工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bafc3e70-4cb8-4c34-96b7-072f4fb8629a.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "5675cc58-ceaa-48bd-8111-ed2e6b1279cf"
+  },
+  {
+    "url": "https://explorer.globe.engineer",
+    "title": "Globe Explorer",
+    "type": "web",
+    "description": "结构化AI知识搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43c8c98e-5035-4d62-9c5b-6d3f965d3e7a.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "65f063c3-6df3-4f61-bf29-5cd43a74975e"
+  },
+  {
+    "url": "https://reportify.cc",
+    "title": "Reportify",
+    "type": "web",
+    "description": "AI投资研究问答搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/117fb7a6-9974-40ad-b685-2e84e103d994.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "f8c3261a-b5cd-49c5-bb41-cde9849d05c4"
+  },
+  {
+    "url": "https://www.phind.com",
+    "title": "Phind",
+    "type": "web",
+    "description": "专为开发者设计的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a08de3ae-fb93-4682-9688-f235e39d21d8.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "b58fdf13-e601-42e1-8159-c9ab5bdb1de6"
+  },
+  {
+    "url": "https://iask.ai",
+    "title": "iAsk AI",
+    "type": "web",
+    "description": "快速准确的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1220e33-4b20-40a0-beb8-2f63057fea45.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "5fd3c716-6926-4b56-931e-fd7429a6a331"
+  },
+  {
+    "url": "https://consensus.app",
+    "title": "Consensus",
+    "type": "web",
+    "description": "AI科研学术搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c061b6c5-018e-47e1-b834-22c243a94895.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "a5da9d32-d9c6-474c-a591-688c206727ab"
+  },
+  {
+    "url": "https://komo.ai",
+    "title": "Komo Search",
+    "type": "web",
+    "description": "简洁直观的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09997be3-f33a-41b7-8142-f4dfaf1c93f8.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "31e0cd6a-28d7-48d7-8293-29b22bc0f84d"
+  },
+  {
+    "url": "https://searcholic.com",
+    "title": "Searcholic",
+    "type": "web",
+    "description": "AI驱动的电子书和文档搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3db37944-b4e0-486e-be9f-8d495e9d7fbb.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "ea68c627-8592-425b-9317-020470c7cedf"
+  },
+  {
+    "url": "https://andisearch.com",
+    "title": "Andi",
+    "type": "web",
+    "description": "对话式人工智能搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/08759ebd-97e2-4379-a894-e9ff7559e597.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "04a57341-ea44-4b7b-8593-7f61f9fe52df"
+  },
+  {
+    "url": "https://www.songtell.com",
+    "title": "Songtell",
+    "type": "web",
+    "description": "AI驱动的音乐百科搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/137cea92-95da-4669-96b8-d281996b26c6.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "9648d516-113f-4881-bebd-d2f6110fabb0"
+  },
+  {
+    "url": "https://thinkany.ai/zh",
+    "title": "ThinkAny",
+    "type": "web",
+    "description": "新时代的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43cdd558-6298-4991-8a83-98727c820923.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "7ac54982-0139-4dd0-b169-f5445f7a1f15"
+  },
+  {
+    "url": "https://www.hellomiku.com",
+    "title": "Miku",
+    "type": "web",
+    "description": "快速精准的搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6df44f0a-e8cb-40c3-90e1-b05b2acac8de.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "7e37a95f-34c8-4fc3-9dad-1c4d41a1508f"
+  },
+  {
+    "url": "https://qdrant.tech",
+    "title": "Qdrant",
+    "type": "web",
+    "description": "开源的向量数据库和向量相似性搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3167d06-940d-4bdd-9b22-b7da8749520b.png",
+    "category": [
+      "搜索引擎"
+    ],
+    "id": "e44ca766-f5d7-4a1f-96ee-ab7bfb1ca979"
+  },
+  {
+    "url": "https://immersivetranslate.com/zh-Hans",
+    "title": "沉浸式翻译",
+    "description": "双语对照的网页翻译插件，完全免费 口碑炸裂！",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5fe5ad13-2cd8-435e-83da-4ceba329c7c1.jpg",
+    "category": [
+      "翻译"
+    ],
+    "id": "4c4aa1e9-7368-4598-8116-445b5e74daa6",
+    "type": "plugin"
+  },
+  {
+    "url": "https://huiyiai.net/",
+    "title": "会译",
+    "description": "沉浸对照式翻译，支持100+语言",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/23389fac-a83d-445c-a8fd-481eec95ea52.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "18e6381a-8eef-4cd0-96b0-a381eae067f6",
+    "type": "web"
+  },
+  {
+    "url": "https://transmart.qq.com",
+    "title": "腾讯交互翻译",
+    "description": "腾讯推出的多语言翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4c8e6aa-b875-4b6e-82c8-5833f5d3c784.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "da9e7ff7-bef6-45a0-a5e7-b70b00a8253d",
+    "type": "web"
+  },
+  {
+    "url": "https://deeptranslate.ai/zh-CN",
+    "title": "DeepTranslate",
+    "description": "免费的AI双语翻译器，支持142+种语言",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a7b50688-869b-42de-8e22-ac12a0012d84.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "f7f8b621-17a8-4690-a5fd-fa45eab0a5a6",
+    "type": "plugin"
+  },
+  {
+    "url": "https://translate.google.com/",
+    "title": "Google翻译",
+    "description": "Google免费提供的上百种语言智能翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/714f695d-58bc-4e5e-a37d-a0d9caf7d819.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "449a7f40-6d4c-451f-a41c-4c7e83ba8668",
+    "type": "web"
+  },
+  {
+    "url": "https://www.bing.com/translator/",
+    "title": "必应翻译",
+    "description": "微软必应推出的翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ce8d6e1a-4744-45ec-9ad1-15f9da10f5c6.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "eab5d132-86cb-4478-937f-fb2d47e93ae2",
+    "type": "web"
+  },
+  {
+    "url": "https://www.deepl.com/translator",
+    "title": "DeepL翻译",
+    "description": "准确的人工智能翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/91666697-0c70-4581-9b6f-6abba2fd4391.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "622ebb49-f9c5-4b92-98b4-4bcd61ad952e",
+    "type": "web"
+  },
+  {
+    "url": "https://www.trytoby.com",
+    "title": "Toby",
+    "description": "AI实时语音翻译工具，专为视频通话设计",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/04c3fb2c-f59c-4529-9f8a-610bca6fac91.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "91fb0ac8-f3a5-4689-bf99-b308241ed4c1",
+    "type": "web"
+  },
+  {
+    "url": "https://translate.volcengine.com/",
+    "title": "火山翻译",
+    "description": "字节跳动推出的智能翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/93e01502-ff8c-4678-8f99-226856d11824.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "3bf21832-ac31-4ebb-bef3-ef25c6d540b0",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.baidu.com/",
+    "title": "百度翻译",
+    "description": "200种语言互译、沟通全世界！",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/69e3adde-0504-4dbe-8264-3ae2ebe0227e.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "64799813-6c8e-4305-862a-294e2b682eda",
+    "type": "web"
+  },
+  {
+    "url": "https://translate.alibaba.com",
+    "title": "阿里翻译",
+    "description": "阿里巴巴达摩院推出的多领域多语种的在线机器翻译",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f729f011-ff5f-4fd4-9210-d20e70782d0c.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "72bbf327-573e-4ca2-95fd-bc0674552e96",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.sogou.com/text",
+    "title": "搜狗翻译",
+    "description": "你的贴身智能翻译专家",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/64c6558e-f6ea-4e16-8a8b-00b3c61f5ec6.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "581eee16-0387-44d9-95cb-73e631e964f9",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.qq.com/",
+    "title": "腾讯翻译君",
+    "description": "你免费的随身翻译",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b898e39e-16d6-442c-8d8c-b95b06c5d180.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "e526af95-1a02-41a8-b6a6-f294504f44af",
+    "type": "web"
+  },
+  {
+    "url": "https://www.xiangjifanyi.com",
+    "title": "象寄翻译",
+    "description": "AI图片和视频翻译神器，支持多种语言的翻译",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cea1d8f1-381f-4bee-b7b7-fe2e5026273e.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "22c5cf2a-46bc-4205-bc2c-71f232d81b3d",
+    "type": "web"
+  },
+  {
+    "url": "https://sight.youdao.com",
+    "title": "网易见外",
+    "description": "网易推出的AI智能翻译平台，支持音视频、文档、图片、字幕等翻译",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/93318218-3f3d-4ab1-9688-e8c27d161f58.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "cbe6f5f4-2445-466c-9857-23ee91e897df",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.xfyun.cn",
+    "title": "讯飞智能翻译",
+    "description": "科大讯飞推出的人工智能翻译平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16547631-38e2-4511-8367-267ad9ae7c9e.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "ba7eae3d-b1cd-4012-9563-b7168083749e",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.caiyunapp.com/#/",
+    "title": "彩云小译",
+    "description": "兼具中日英同声传译、文档翻译和网页翻译的智能翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39f25462-782f-405e-9611-0121cdb4bc8c.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "d234eeb9-f894-4e6c-beb5-3a77b8e3336f",
+    "type": "web"
+  },
+  {
+    "url": "https://fanyi.baidu.com/appdownload/download.html?tab=helper&fr=pcproduct",
+    "title": "百度AI同传助手",
+    "description": "中英文音视频同传字幕工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/309b33bb-990c-4a45-acaa-ac566c985ed9.png",
+    "category": [
+      "翻译"
+    ],
+    "id": "304cfa42-ac20-4ad1-a286-ff4975706d0e",
+    "type": "app"
+  },
+  {
+    "url": "https://www.aippt.cn",
+    "title": "AiPPT",
+    "description": "AI快速生成高质量PPT",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4c8e5d9c-2f19-413a-8af2-a3bd8d6f5a25.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "12c81350-83ac-43d4-8bb4-1245283b3a06"
+  },
+  {
+    "url": "https://www.cappt.cc",
+    "title": "咔片PPT",
+    "description": "AI PPT制作工具，设计美化全流程自动化",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a284ecc-04ab-4690-87fd-51ebc9386379.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "bc903f07-a84e-41ec-a475-553f619e14b0"
+  },
+  {
+    "url": "https://www.bigppt.cn",
+    "title": "笔格AIPPT",
+    "description": "高效的AI PPT生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/198670d2-fdfd-4d21-94a4-a9be92a1f0b9.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "0c47682f-6c34-46f7-b9b6-b972d00ad5f1"
+  },
+  {
+    "url": "https://docmee.cn",
+    "title": "文多多AiPPT",
+    "description": "AI一键生成PPT，支持AI配图和智能资料整合",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/986b7358-5f68-4922-acf9-35ee1c7be44e.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "49178110-81d3-4d6e-b6ea-db0bf962a8c1"
+  },
+  {
+    "url": "https://gamma.app/",
+    "title": "Gamma App",
+    "description": "AI幻灯片演示生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e8301984-bd42-492e-ba0f-401366f3747a.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "275fd305-bfd9-4110-a7a8-d71f01641ad5"
+  },
+  {
+    "url": "https://chatglm.cn/main/alltoolsdetail",
+    "title": "清言PPT",
+    "description": "智谱清言联合AiPPT推出的PPT生成智能体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d3f45c96-1c76-40f3-8899-2d6f88e07611.jpg",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "527e973d-3904-420f-a53f-5e42bfc5179a"
+  },
+  {
+    "url": "https://www.islide.cc",
+    "title": "iSlide AIPPT",
+    "description": "AI一键设计精美PPT，只需一句标题",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c6e6481-a5c6-48ac-8694-3cc87c58d9cf.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "b2470737-fb6a-46f7-b336-e63cea52ddb6"
+  },
+  {
+    "url": "https://www.gaoding.com",
+    "title": "稿定PPT",
+    "description": "稿定推出的PPT模板资源库",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0f1fb71f-b46d-4a38-a0e0-4ad16a54b8b4.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "dd51983b-163d-4041-a9d9-805cf632173d"
+  },
+  {
+    "url": "https://ibiling.cn/ppt-zone",
+    "title": "笔灵AIPPT",
+    "description": "一键生成PPT和千字演讲稿",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/828f97a5-3d3e-4d8f-9a8a-a57c9bb4960d.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "637edd3a-690b-44f2-8f75-85af00381983"
+  },
+  {
+    "url": "https://zhiwen.xfyun.cn",
+    "title": "讯飞智文",
+    "description": "科大讯飞推出的免费AI PPT生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3a5d653e-4f50-452c-96c0-95cdc035842e.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "de1e3a14-0ea7-4392-8d11-1066ee0c4369"
+  },
+  {
+    "url": "https://wenku.baidu.com/ndlaunch/browse/chat",
+    "title": "百度文库AI助手",
+    "description": "基于文心一言的一站式智能文档助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac7fc06c-7907-4124-b1cf-64cb93c80ac9.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "22e2ad34-208a-4877-a40c-025f7b1fab07"
+  },
+  {
+    "url": "https://zhiyan.wondershare.cn",
+    "title": "万兴智演",
+    "description": "万兴科技推出的AI PPT和演示制作软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7f129dd-49dc-4ba7-afc9-6047ba7fdb0e.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "be49321d-cce2-4fae-9616-9a9d216e8cee"
+  },
+  {
+    "url": "https://www.napkin.ai",
+    "title": "Napkin",
+    "description": "将文本内容快速转换成演示图像的AI办公工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/12198477-d272-4dab-8fea-a0e0bdd23987.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "48907b63-91e6-4156-a63c-e970ad5a608c"
+  },
+  {
+    "url": "https://www.visdoc.cn",
+    "title": "VisDoc",
+    "description": "AI文生图表工具，支持生成柱状图、折线图、饼图等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5de01e8-2de6-469e-bbb8-7f6208d144e4.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "6552c4a0-862c-4f5d-8ef9-bef0882cb93b"
+  },
+  {
+    "url": "https://www.designkit.com/ppt",
+    "title": "美图AI PPT",
+    "description": "美图秀秀推出的免费在线AI生成PPT设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee4c6251-e231-43f8-979f-25cbac371590.jpg",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "2d50a420-a620-4d84-8947-91d6443d5baa"
+  },
+  {
+    "url": "https://www.wanzhi01.com",
+    "title": "万知",
+    "description": "零一万物推出的一站式AI文档阅读和PPT创作工作台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aaa68ae9-e9ae-44ed-ab96-38b0c490ccfb.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "7eee2fdc-ccd8-4c99-a872-a800dda99d17"
+  },
+  {
+    "url": "https://gezhe.caixuan.cc",
+    "title": "歌者AI",
+    "description": "彩漩PPT推出的AI PPT生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/566efdfb-1b6d-48cf-b682-cb82ac9d0d84.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "d64b47d1-e587-4f02-a363-f0796ee0b526"
+  },
+  {
+    "url": "https://www.chatba.com/",
+    "title": "ChatBA",
+    "description": "AI幻灯片生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2e2c29b-24b8-49a9-b884-e7d6eaa741cb.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "17c38e8d-6f54-4d76-a3d7-a05d738b4f4a"
+  },
+  {
+    "url": "https://tome.app/",
+    "title": "Tome",
+    "description": "AI创作叙事性幻灯片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5f12d17c-7c43-46ce-bfcf-31cb71c936b5.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "195f97f3-7047-48ce-a84c-7f1d210c41d4"
+  },
+  {
+    "url": "https://www.decktopus.com/",
+    "title": "Decktopus AI",
+    "description": "AI驱动的的在线演示文稿生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82c43066-0205-4575-aeeb-ccd91d9b7a10.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "23dde9b0-c9fb-4a68-959d-4191ee383ea2"
+  },
+  {
+    "url": "https://powerpresent.ai/",
+    "title": "Powerpresent AI",
+    "description": "AI创建精美的演示稿",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20c04ed0-0fe6-4893-a44b-42e9f1c7fe9e.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "57408997-526d-49df-accb-a987fee902a3"
+  },
+  {
+    "url": "https://easinote.seewo.com",
+    "title": "希沃白板",
+    "description": "专为互动教学设计的AI课件生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/85d06107-1464-41a8-be8b-69bc6e089830.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "6f0788d5-08df-4168-8d13-3c9c7e111897"
+  },
+  {
+    "url": "https://10sppt.com/pptx",
+    "title": "秒出PPT",
+    "description": "一键生成PPT，智能辅助编辑",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bb17547d-4074-42c6-a411-ce6f6b21d21b.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "1e517cbe-df8d-4fa7-b04b-92391ab1fa04"
+  },
+  {
+    "url": "https://www.gaippt.com",
+    "title": "GAIPPT",
+    "description": "AI智能美化PPT工具，上传PPT一键美化",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/086fc822-b12f-4cb2-a17e-02fd3b0d708a.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "21ebd126-a5ac-4f46-bf54-9d56f2637c51"
+  },
+  {
+    "url": "https://www.beautiful.ai/",
+    "title": "beautiful.ai",
+    "description": "AI创建展示幻灯片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14f250fe-1762-40dd-af36-d46368d0c787.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "f024bc13-ff64-43a7-a6fc-8ddb432480f3"
+  },
+  {
+    "url": "https://www.mindshow.vip/workstation",
+    "title": "麦当秀MindShow",
+    "description": "AI在线PPT制作工具，支持Markdown等多种格式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8d97253-7735-4400-93d1-bdd4a9482c21.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "7bfe20b1-7a70-4114-a5df-cff5d859cec8"
+  },
+  {
+    "url": "https://www.chat-ppt.com/",
+    "title": "ChatPPT",
+    "description": "AI一键对话生成PPT，智能排版美化",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f366066a-9cac-4ae2-94f8-f19e78d2ae6b.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "74f808cf-d309-4dfd-8fc6-6fe60d1a74cd"
+  },
+  {
+    "url": "https://pptgo.cn",
+    "title": "博思AIPPT",
+    "description": "博思云创推出的在线AI生成PPT工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d3b5fb5-1fad-41a9-87f8-f65fc74c15a9.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "439cbe11-dedf-48ed-9122-9ae2dbdb437a"
+  },
+  {
+    "url": "https://qzoffice.com",
+    "title": "轻竹办公",
+    "description": "在线智能生成和设计PPT的AI工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f1bb6c5-b528-4695-b80f-d9b854330419.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "e36aaca3-611a-499c-a722-be70372d1fa9"
+  },
+  {
+    "url": "https://chroniclehq.com/",
+    "title": "Chronicle",
+    "description": "AI高颜值演示文稿创建",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4dea533-fe0c-4c85-a03e-608a288dc44d.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "7ab4c78c-55b2-4bb6-bfab-0cdef77aa9f4"
+  },
+  {
+    "url": "https://www.presentations.ai/",
+    "title": "Presentations.AI",
+    "description": "演示文档版的ChatGPT",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20f2c45d-0bfc-46bd-948a-462c2eabc246.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "0f1dc28f-fb66-434e-8df0-b13993ab0c0e"
+  },
+  {
+    "url": "https://www.slidesai.io/",
+    "title": "SlidesAI",
+    "description": "AI快速创建演示幻灯片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edde2d9a-02e0-4e34-8f03-1277a3f7e344.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "edf825bd-4cf0-48f7-b798-22a268c45210"
+  },
+  {
+    "url": "https://www.auxi.ai/",
+    "title": "auxi",
+    "description": "功能强大的PowerPoint AI插件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f20d86d-fec6-445e-8538-e1a9b50dff41.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "1377a56f-894c-413c-b9e0-2c0ba0be20ac"
+  },
+  {
+    "url": "https://www.lgppt.cn",
+    "title": "AI灵感PPT",
+    "description": "免费高效的AIPPT生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6c3b82c9-4610-4e8a-a596-ae55bbe03a60.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "201f5e33-c8b6-4d7d-b19a-9aaef87ef2c6"
+  },
+  {
+    "url": "https://www.mindshow.fun",
+    "title": "MindShow",
+    "description": "国内独立开发者开发的输入内容自动生成演示工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fc649f08-a16e-417d-8a9f-730abcef99db.png",
+    "category": [
+      "PPT"
+    ],
+    "type": "web",
+    "id": "5d9da23a-e26d-4eab-8e58-e0bd4e676c9e"
+  },
+  {
+    "url": "https://www.chatexcel.com/#/home",
+    "title": "酷表ChatExcel",
+    "description": "AI Excel 数据分析辅助工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c36b615a-f9d9-46a8-8c0a-5bb07a7cfc43.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "725a6ef0-0b12-437b-8faf-23e861e8ce04"
+  },
+  {
+    "url": "https://www.xiaohuanxiong.com",
+    "title": "办公小浣熊",
+    "description": "商汤科技推出的AI办公助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8180c38b-e3aa-4ce6-8cc8-705f144f9884.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "f53b1f86-3620-472a-ac7d-82cb143fae95"
+  },
+  {
+    "url": "https://vika.cn",
+    "title": "vika维格云",
+    "description": "智能多维表格和数据生产力平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb9432e5-b835-4e29-ac6f-bb1737b9449f.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "ce747325-516d-461c-b0e2-b65b30ec93e0"
+  },
+  {
+    "url": "https://gbi.cloud.baidu.com",
+    "title": "百度GBI",
+    "description": "百度推出的全球商业智能平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c37fc473-045e-4c0a-baff-284e0c0f6519.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "141e6e46-8ac7-442d-9d25-0f17c975a89e"
+  },
+  {
+    "url": "https://ajelix.com/",
+    "title": "Ajelix",
+    "description": "处理Excel和Google Sheets表格的AI工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54a37c98-ee88-499c-9d85-c5b6bb5148f2.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "0f767b31-fe0e-4fae-bdc7-6b3c248718da"
+  },
+  {
+    "url": "https://sheetplus.ai/",
+    "title": "Sheet+",
+    "description": "Excel和Google Sheets表格AI处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/52e04344-429c-473f-8156-32539e889af0.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "4c48a2f7-9b97-4926-8b27-28ec67752b1f"
+  },
+  {
+    "url": "https://cloud.yoo-ai.com",
+    "title": "轻云图",
+    "description": "必优科技推出的AI一键生成可视化云图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/879dd823-acb6-4e5c-911b-f2af856eea8e.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "04807ae6-69ad-4f48-bf54-b57b30d9875b"
+  },
+  {
+    "url": "https://datarc.cn",
+    "title": "北极九章",
+    "description": "北极数据推出的AI数据分析平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8f43b24-a309-436f-8d9e-a8ca43c9a166.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "508d9593-a76d-4620-953c-3179ed44fa88"
+  },
+  {
+    "url": "https://excelformulabot.com",
+    "title": "Formula bot",
+    "description": "AI将指令转换成Excel的函数公式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01594f20-5c66-4c89-9e2a-b21f101e3985.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "e161d8d7-ce36-436a-9d5b-a4010058fb00"
+  },
+  {
+    "url": "https://www.formx.ai/",
+    "title": "FormX.ai",
+    "description": "AI自动从表格和文档中提取数据",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4a9900c-a8a2-436b-bd21-9b998919ac6e.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "624bbdd0-d649-495b-ace4-29b5f0751b32"
+  },
+  {
+    "url": "https://rows.com/",
+    "title": "Rows",
+    "description": "集成了AI功能的在线表格处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/df150d87-027f-4723-9202-b685fe9e2fef.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "0210c12d-8487-4501-89f3-a156a69d377f"
+  },
+  {
+    "url": "https://excelly-ai.io/index.html",
+    "title": "Excelly-AI",
+    "description": "将文本转换成Excel或Google Sheets公式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5ad750c3-5e3a-45ee-8f16-bc98e1983115.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "398f8ae5-2e7c-40ea-85dc-3b1f3b137e3c"
+  },
+  {
+    "url": "https://www.boloforms.com/sheetgod/",
+    "title": "SheetGod",
+    "description": "BoloForms推出的AI Excel公式生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1895ec58-3293-4fa4-87f9-e00ff742e745.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "55b580cf-1405-4a26-be40-15ddd60ab697"
+  },
+  {
+    "url": "https://excelformularizer.com/",
+    "title": "Excel Formularizer",
+    "description": "AI将文本输入转换为Excel公式处理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7667c876-7f59-403d-bc1e-741f45168db7.png",
+    "category": [
+      "表格"
+    ],
+    "type": "web",
+    "id": "f79306d6-9a3c-44b0-8a24-87725bc8ceb7"
+  },
+  {
+    "url": "https://baoyueai.com/channel",
+    "title": "包阅AI",
+    "description": "高效的AI智能阅读助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3df395cd-6118-4d75-8a84-328e5452590d.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "3f94a105-9565-42e5-a166-06443d309567"
+  },
+  {
+    "url": "https://www.txyz.ai",
+    "title": "txyz",
+    "description": "AI文献阅读和学术研究辅助平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80ba9566-28b0-458a-b098-0689d0a0b5cf.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "d87e2538-1628-49ab-965d-cb452b6eba5c"
+  },
+  {
+    "url": "https://noedgeai.com",
+    "title": "Doc2X",
+    "description": "AI文档识别、转换与翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f34ab4aa-8c7d-4e32-969d-846fbb35acc9.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "d450e171-0944-4831-a7ef-4031a9c48744"
+  },
+  {
+    "url": "https://www.adobe.com/acrobat/generative-ai-pdf.html",
+    "title": "Acrobat AI Assistant",
+    "description": "Adobe推出的Acrobat PDF文档AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8af5508-c465-4868-8fc6-fa0b797e5655.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "b7e770d8-bce1-4670-bfde-6959e147bb1e"
+  },
+  {
+    "url": "https://ai.wps.cn",
+    "title": "WPS AI",
+    "description": "WPS推出的AI办公助手，已免费开放",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ba396fb2-0e31-4ff9-8241-75c280cd0ddf.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "016cc4c3-12ac-47d3-a0f0-dba5ce74b84f"
+  },
+  {
+    "url": "https://docs.qq.com",
+    "title": "腾讯文档智能助手",
+    "description": "腾讯推出的AI文档生成和辅助工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5332c89f-92ec-4776-a03f-0cbbf91ac59b.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "15adda4e-8994-4f15-aff1-91864dbdca63"
+  },
+  {
+    "url": "https://cubox.pro",
+    "title": "Cubox",
+    "description": "高效的AI阅读学习助手和信息收集管理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a8ba6c5-8e6c-4d11-880d-775de5d1c6a0.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "1c7aff2f-e6fa-4fc0-8b6b-7f93175227b9"
+  },
+  {
+    "url": "https://www.quivr.app",
+    "title": "Quivr",
+    "description": "开源的知识库搭建工具，构建你的第二大脑",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a1ef919-c109-41cf-8f86-ffc06a673a6c.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "7e94a5c5-e977-498d-b35a-b511f76fbd06"
+  },
+  {
+    "url": "https://coda.io/product/ai",
+    "title": "Coda AI",
+    "description": "在线协作平台Coda推出的AI写作和文档助手，类似于Notion AI",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6bd76e96-0487-4fc7-8d2b-aeaa86ed5392.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "00973ceb-aff9-4394-9a5c-5d84c4d93e6c"
+  },
+  {
+    "url": "https://read.youdao.com",
+    "title": "有道速读",
+    "description": "网易有道推出的AI论文和文档阅读助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/02dc9306-f803-4264-ba0a-e719a1d5567d.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "ef722785-e3f6-4b29-819e-c7aea0386bed"
+  },
+  {
+    "url": "https://wj.qq.com/ai/generate.html",
+    "title": "腾讯问卷",
+    "description": "腾讯推出的AI生成调查问卷的免费工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0d3210f3-d1d0-4a91-90a0-c92277af51e7.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "1827f231-621f-4663-b712-ad25a8e26959"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/zhiwen",
+    "title": "通义智文",
+    "description": "基于通义大模型的AI阅读助手，可智能阅读网页、论文、图书和文档",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1963657f-1a9b-4675-be47-c7a4d47a996b.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "a3994d48-7cf8-4c19-b396-fac692fcfaff"
+  },
+  {
+    "url": "https://getgetai.com",
+    "title": "字语智能",
+    "description": "一站式智能Office内容创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a77e61ca-1a4f-46d3-97a5-647fde1298e5.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "e7af6ae4-91fe-4394-8fed-3f89ee504bff"
+  },
+  {
+    "url": "https://chatdoc.xfyun.cn",
+    "title": "星火文档问答",
+    "description": "基于讯飞星火大模型的AI文档和知识库问答助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79f32d40-673a-49b5-a547-57edf4186095.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "50da344e-2d41-4897-bf10-50556fbeba4b"
+  },
+  {
+    "url": " https://www.pm-ai.cn",
+    "title": "PMAI",
+    "description": "面向产品经理的AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6aa31a7-6d15-4351-b942-a7e0b121c1e2.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "893632a9-686d-4060-853f-7cd7d94fb3f8"
+  },
+  {
+    "url": "https://pdf.ai",
+    "title": "PDF.ai",
+    "description": "AI PDF文档阅读工具，智能文档总结摘要",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/255446fb-e776-4010-a223-7b66c63b4ab7.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "04d4656e-acf2-458c-8fac-5a8bef0c01b5"
+  },
+  {
+    "url": "https://smartread.cc",
+    "title": "司马阅",
+    "description": "AI文档阅读分析工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6f8e3b43-f965-40d8-b8e7-e26094fdd7fc.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "438440b5-a09c-4ab2-924c-a009f4904dd4"
+  },
+  {
+    "url": "https://knowme.xiaoduoai.com",
+    "title": "知我AI",
+    "description": "智能阅读机器人，AI总结文档、网页、视频、播客等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a133838c-dfe0-4bf1-97f4-dcea60581e3b.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "49905916-2f4b-4673-8ea4-92f63b42b908"
+  },
+  {
+    "url": "https://paper.iflytek.com",
+    "title": "星火科研助手",
+    "description": "科大讯飞联合中科院推出的AI科研文献助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e93492b1-bd6f-42db-a6ee-9a7771cf12c7.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "83e345a1-db30-41c2-9884-572c5412fbfd"
+  },
+  {
+    "url": "https://www.yinxiang.com/about/yxai-yxbj/",
+    "title": "印象AI",
+    "description": "印象笔记推出的AI知识和信息管理功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5df18a60-1c44-4871-9bdb-a97bdfb56066.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "47e6ab39-ba94-42ed-af20-70ea33aa83c7"
+  },
+  {
+    "url": "https://www.craft.do",
+    "title": "Craft AI Assistant",
+    "description": "在线文档工具Craft推出的AI文档和创作助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7fbe47f-07f1-4786-a1d9-3891e990e60e.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "17a42f60-9ac8-4ce6-96ff-948c73838c79"
+  },
+  {
+    "url": "https://www.humata.ai/",
+    "title": "Humata",
+    "description": "基于GPT的AI文档分析、阅读和问答工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6f41c8c4-1e03-4dd4-b022-f2661f223688.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "881b155a-02e8-4c97-9e1c-b3b1ca6721c6"
+  },
+  {
+    "url": "http://chatdoc.com",
+    "title": "ChatDOC",
+    "description": "基于ChatGPT的文档阅读、提取、总结、摘要的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3f3b3994-f2d1-43ee-b33d-266d38ad6cac.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "703054c7-322b-489e-aa37-f8844938a6cb"
+  },
+  {
+    "url": "https://www.pandagpt.io/",
+    "title": "PandaGPT",
+    "description": "AI文档要点总结工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dc694990-77c6-4623-bf06-d387258e8fae.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "59658131-3aa1-4544-a247-cbb2ec721c6b"
+  },
+  {
+    "url": "https://rossum.ai/",
+    "title": "Rossum.ai",
+    "description": "现代化的AI文档处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6dd0a980-d444-45bb-beda-de381ad2cc1f.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "1ef2f968-efe7-42fb-81e9-e37f046bf4b5"
+  },
+  {
+    "url": "https://super.ai/",
+    "title": "Super AI",
+    "description": "AI复杂文档自动识别处理转换",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ceedc84-f916-4758-a04c-549c2cba6de8.png",
+    "category": [
+      "文档工具"
+    ],
+    "type": "web",
+    "id": "094a381a-5291-48d4-8576-992639855d53"
+  },
+  {
+    "url": "https://shutu.cn",
+    "title": "TreeMind树图",
+    "description": "新一代AI智能思维导图，一句话生成思维导图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8d0cc96c-b4d7-4e3e-be31-5f5c8fb039bc.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "ea011fec-5d90-4f03-94cd-a587d069adcb"
+  },
+  {
+    "url": "https://boardmix.cn/ai-whiteboard",
+    "title": "博思白板",
+    "description": "博思云创推出的AI多功能白板工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/97cf28fb-287b-46d7-885e-0ae8bc5a2dc2.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "0e3aedd5-db50-485d-8796-a3d4e2705a31"
+  },
+  {
+    "url": "https://www.processon.com",
+    "title": "ProcessOn",
+    "description": "在线AI流程图和思维导图制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c59a0071-7dba-4677-9526-426683a1df60.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "c52e47dc-9901-49e8-a62e-19efded3c11e"
+  },
+  {
+    "url": "https://wenku.baidu.com/pcactivity/freeBoard",
+    "title": "自由画布",
+    "description": "百度文库和百度网盘联合推出的AI万能白板",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3768413a-5eba-4c5c-86a1-c95b50b03a3a.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "6720b3f4-7c82-4255-bc5d-5771ed2cbf51"
+  },
+  {
+    "url": "https://www.edrawsoft.cn/mindmaster",
+    "title": "亿图脑图",
+    "description": "亿图脑图思维导图助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/140fa2dc-21f1-488e-9762-9938f0faf076.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "5e018511-bb00-40ef-9fd1-e0930752d5ec"
+  },
+  {
+    "url": "https://imiaoban.com",
+    "title": "妙办画板",
+    "description": "在线实时协作的画图工具，AI一键生成流程图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f431309b-2a9e-4e4e-a067-1c3d066418f9.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "1aedbe19-3944-40e5-8a8e-a5c22da705cf"
+  },
+  {
+    "url": "https://mapify.so/cn",
+    "title": "Mapify",
+    "description": "Xmind推出的思维导图生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/074fcfe7-8058-4c63-a239-eb8163f4ba91.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "3bca3a14-e081-458a-b8b2-b887104e81d3"
+  },
+  {
+    "url": "https://www.xiaohuazhuo.com",
+    "title": "小画桌",
+    "description": "在线协作白板工具，内置AIGC功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ed22ebf7-e6c4-420a-8be2-ca679f165b3c.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "5016c01e-610f-416c-bdcb-a0b301f6cf6f"
+  },
+  {
+    "url": "https://www.yinxiang.com/product/evermind/",
+    "title": "印象图记",
+    "description": "印象AI加持的在线思维导图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a1bdcf8b-df2b-4637-a52f-d2c89f85fdde.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "11f5aec8-314c-4efc-a861-02b755cbd3e4"
+  },
+  {
+    "url": "https://www.swdt.com",
+    "title": "知犀AI",
+    "description": "知犀推出的思维导图生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c590132-6869-458c-a723-04698f833a4f.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "bced0743-092f-4af6-900f-d631cf44fcb1"
+  },
+  {
+    "url": "https://xmind.ai",
+    "title": "Xmind Copilot",
+    "description": "Xmind 思维导图助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a2a85a9-5880-45a6-a9f4-8a48b03c4baf.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "e5f90b6c-f58c-49fb-984a-bbf8877e3dc2"
+  },
+  {
+    "url": "https://imiaoban.com/work/AIht",
+    "title": "妙办AI画图工具",
+    "description": "AI免费一键生成流程图、思维导图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8f0cfc20-a963-401a-be05-cda305af819c.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "8b1a6125-e6e6-443e-af0f-8cf81d4ecdc0"
+  },
+  {
+    "url": "https://gitmind.cn",
+    "title": "GitMind思乎",
+    "description": "AI驱动的免费思维导图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cc507600-2e6c-4efc-aeb2-d95fa1dbea3c.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "d4cef4c1-577a-491a-af58-43a5b8af3b9e"
+  },
+  {
+    "url": "https://www.edrawsoft.cn/edrawmax/ai",
+    "title": "亿图图示AI",
+    "description": "专业的办公绘图软件，轻松绘制图表和图形",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8d1da4b-5d28-4ef5-b6ac-88d8ea487721.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "d577db3c-ac8a-43e5-978d-be2863e8f919"
+  },
+  {
+    "url": "https://whimsical.com/ai-mind-maps",
+    "title": "Whimsical",
+    "description": "Whimsical推出的思维导图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a4748e7-aac1-48a9-80de-c6f202b210fb.gif",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "6f93fd7e-caa2-4f19-ba13-cc76567b6176"
+  },
+  {
+    "url": "https://amymind.com",
+    "title": "AmyMind",
+    "description": "开箱即用的在线思维导图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/62fb368c-93d2-41a1-95a9-a8442cb31db0.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "8ef3ff95-df77-4ebe-ab0a-47c0bb28d9a6"
+  },
+  {
+    "url": "https://www.taskade.com/",
+    "title": "Taskade",
+    "description": "高颜值AI大纲和思维导图生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/411bdd6b-0940-4207-bf99-67bf71fa380c.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "4e04d3a8-8db0-4cd1-aa84-00fbf7449fb0"
+  },
+  {
+    "url": "https://miro.com/mind-map/",
+    "title": "Miro AI",
+    "description": "在线白板协作工具推出的AI功能，Beta测试中",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4b96964-613e-47b3-989d-8d523f75c23b.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "40b80c4a-78c7-4bf6-966e-6eb15c0d5d65"
+  },
+  {
+    "url": "https://www.ayoa.com/ultimate/",
+    "title": "Ayoa Ultimate",
+    "description": "思维导图和头脑风暴工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6545320-7dfc-4d7b-9108-d7af2a5bb675.png",
+    "category": [
+      "思维导图"
+    ],
+    "type": "web",
+    "id": "8f6d1c2a-f1c2-41e5-8f81-28cb5cf74055"
+  },
+  {
+    "url": "https://itingnao.com",
+    "title": "听脑AI",
+    "description": "人工智能语音录音记录助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/36e91984-7694-4e55-b898-90e4e8d14d69.png",
+    "category": [
+      "会议工具",
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "49a98b04-ce09-4cda-9dd9-043d01385056"
+  },
+  {
+    "url": "https://pan.baidu.com/embed/listennote",
+    "title": "简单听记",
+    "description": "百度网盘推出的AI语音转文字工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3dabd275-e5e6-44f9-a0f0-dd2231c61dde.png",
+    "category": [
+      "会议工具",
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "d0ebe59b-db52-4f7a-9016-2f7d05971404"
+  },
+  {
+    "url": "https://tingwu.aliyun.com",
+    "title": "通义听悟",
+    "description": "阿里推出的AI会议转录工具，万语千言，心领神悟",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/22068cb7-96f5-4360-8624-4d8a890339f3.png",
+    "category": [
+      "会议工具",
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "e5104e6a-200b-422c-a827-e2a3c55f316b"
+  },
+  {
+    "url": "https://meeting.iflyrec.com",
+    "title": "讯飞会议",
+    "description": "AI智能会议系统，实时字幕、实时翻译、自动生成会议记录",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bc8b123-3acf-41ab-bc70-011764b8194a.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "app",
+    "id": "e7edfee3-7273-4ee6-9138-4e64418e2446"
+  },
+  {
+    "url": "https://www.feishu.cn/product/minutes",
+    "title": "飞书妙记",
+    "description": "飞书智能会议纪要和快捷语音识别转文字",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6c87cd8c-c270-43bc-aba0-219b6bcfb8cc.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "c6f24889-3d24-485d-ac58-bd30c2c2574a"
+  },
+  {
+    "url": "https://otter.ai",
+    "title": "Otter.ai",
+    "description": "AI会议内容生成和实时转录",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5d931953-f65e-417e-975a-9cfbb8ee2365.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "94dcb0e9-80f9-49a7-8717-ad6a7477525a"
+  },
+  {
+    "url": "https://meeting.tencent.com/ai",
+    "title": "腾讯会议AI小助手",
+    "description": "腾讯会议推出的AI会议内容助理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/77f8d144-2957-4279-a566-f01f9f020f65.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "c6f7826a-932f-4559-b353-56e858fc3991"
+  },
+  {
+    "url": "https://www.zoom.com/zh-cn/products/collaboration-tools/",
+    "title": "Zoom Workplace",
+    "description": "Zoom推出的AI办公协作和交流沟通平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f42c894-84d4-49d4-8141-e306f0752985.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "65339807-30c0-4a8a-b4e0-c599d77be98b"
+  },
+  {
+    "url": "https://work.duiopen.com",
+    "title": "麦耳会记",
+    "description": "思必驰推出的AI会议助手，语音转文字、字幕同传、AI摘要",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f0b8e53-9e42-4f79-9106-6d5b3d973add.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "15c953c7-6492-45ba-b1f8-a27274fbfd87"
+  },
+  {
+    "url": "https://fireflies.ai/",
+    "title": "Fireflies.ai",
+    "description": "AI会议转录和会议纪要生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d794e54-2ebc-4e36-9e9d-0fc109eddeab.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "e430e590-caea-49e1-a87c-ebb43f57124f"
+  },
+  {
+    "url": "https://noty.ai/",
+    "title": "Noty.ai",
+    "description": "ChatGPT驱动的AI会议转录工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/808ebc45-38c8-428c-ad97-0387744c9aae.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "e84d07a8-d76b-494e-bfc6-9e2567059bac"
+  },
+  {
+    "url": "https://www.airgram.io",
+    "title": "Airgram",
+    "description": "自动会议笔记和总结的AI助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/933c8113-b725-48aa-ae61-5a325f4488ec.png",
+    "category": [
+      "会议工具"
+    ],
+    "type": "web",
+    "id": "e0532822-0537-4868-a9f3-06a6041c65e9"
+  },
+  {
+    "url": "https://offergoose.cn",
+    "title": "多面鹅",
+    "description": "免费大厂面试模拟器，线上面试答案提词器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/37cd65ef-1a0d-40fd-ac33-80fb34d51089.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "d4f9ebeb-2b16-4fb6-8c2e-ed378a1c9d3a"
+  },
+  {
+    "url": "https://mercor.com",
+    "title": "Mercor",
+    "description": "招聘求职求职平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9f6a0b3-e141-4f2f-ae6e-813210b8e7b9.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "93511733-0fa5-4f92-a7d9-d9d9048e02ee"
+  },
+  {
+    "url": "https://www.offerin.cn",
+    "title": "Offerin",
+    "description": "AI面试笔试助手，精准识别面试问题秒级生成答案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2c168795-cdc5-42be-a727-f3394d6ffee6.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "c4a82d36-5234-458a-8c60-efb4ce6bce0b"
+  },
+  {
+    "url": "https://aiqtools.cn",
+    "title": "智面星",
+    "description": "AI面试辅助工具，提供全流程的面试辅助",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f865aa29-4054-4782-a756-be39c43b934a.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "app",
+    "id": "1a033649-21b2-4255-9add-177ded01bb4e"
+  },
+  {
+    "url": "https://m.baigua.com",
+    "title": "白瓜面试",
+    "description": "在线AI面试助手，快速生成面试问题的答案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a4faff1-a7a5-4d0b-bd45-d4c2e507c5e0.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "977ba3a3-9922-4b91-9d0e-ae9a3752bc2c"
+  },
+  {
+    "url": "https://www.52cv.com",
+    "title": "职徒简历",
+    "description": "智能简历制作软件，基于GPT的简历优化和简历代写",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ea6b1959-ce04-41dd-800e-ab7c2f841cf3.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "67a116d9-9756-4ee7-9d31-e87d28fe1225"
+  },
+  {
+    "url": "https://www.zdjianli.cn",
+    "title": "职得简历",
+    "description": "在线AI简历生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c39f2020-5f8f-49dd-a686-3c4fe2690b1d.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "dc5bcf3a-e690-42af-9a0a-aea544b717cf"
+  },
+  {
+    "url": "https://www.lanzidian.com",
+    "title": "蓝字典AI求职",
+    "description": "AI求职工具，提供AI简历生成、AI模拟面试服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54419678-9a22-4660-9806-40ef75a973db.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "c1ee1a76-e189-4aac-b59f-0e5437c68faa"
+  },
+  {
+    "url": "https://jianli.jiuyeqiao.cn/#/index/index",
+    "title": "神笔简历",
+    "description": "AI简历云平台，专为求职者提供一站式求职服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/54b42a85-b07c-4988-9ec9-c4b33b9a668b.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "3be7285d-6f9c-47fc-8e10-61dc2b71a0a6"
+  },
+  {
+    "url": "https://www.yoojober.com",
+    "title": "YOO简历",
+    "description": "必优科技推出的AI简历生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e1a4c1da-4b0a-4834-a6d3-0a701cbfec5e.png",
+    "category": [
+      "招聘求职求职"
+    ],
+    "type": "web",
+    "id": "f37a1fc2-9c56-4af3-aa86-719c5b247a05"
+  },
+  {
+    "url": "https://www.feishu.cn/paid/ai-register",
+    "title": "飞书多维表格",
+    "description": "表格形态的 AI 工作流搭建工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/239a1bc7-48c9-4800-8085-e30e58579f18.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "3fd60151-d469-46b7-9005-fe0c26b60cce"
+  },
+  {
+    "url": "https://manus.im",
+    "title": "Manus",
+    "description": "Monica团队推出的全球首款通用型 AI Agent",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c9a9a58-0c29-4b69-9d0a-010511abd3e9.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "e9c5551d-f348-46c5-a6b6-f9bf5ac804a1"
+  },
+  {
+    "url": "https://ideahunter.today",
+    "title": "IdeaHunter",
+    "description": "基于公开需求信号发现并验证应用与微型 SaaS 创业想法",
+    "image": "https://ideahunter.today/logo.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "73967cab-32af-4235-8521-b562e788981c"
+  },
+  {
+    "url": "https://tinywow.com/",
+    "title": "TinyWow",
+    "description": "免费在线AI工具箱",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/17051054-f2ba-4494-96bf-f9ef6787cf31.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "005099f5-790f-4180-90ac-d456b3ba44d3"
+  },
+  {
+    "url": "https://ima.qq.com",
+    "title": "ima.copilot",
+    "description": "腾讯推出的AI智能工作台产品，基于混元大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8400332-9f00-41d7-a9ac-d098638be3a2.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "dc0cc7cb-5f39-4f4d-800a-66f06a7bf463"
+  },
+  {
+    "url": "https://ask.feishu.cn/topic",
+    "title": "飞书知识问答",
+    "description": "飞书智能办公推出的AI知识库工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f62f59ce-3f90-40fa-81d4-b0b6d2b2ad9e.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "0c0ebe2e-2c9f-415a-8172-c8dade840067"
+  },
+  {
+    "url": "https://monica.cn",
+    "title": "Monica",
+    "description": "全能AI助手，提供聊天、搜索、写作、翻译等多功能服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f500aac-d695-4851-be8c-e2ca1a0d87f5.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "15ac6e1a-8ad9-47be-a43d-2fb05accb226"
+  },
+  {
+    "url": "https://lingxi.wps.cn",
+    "title": "WPS灵犀",
+    "description": "WPS推出的AI办公助手，支持PPT生成、AI写作",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81269afc-60b3-4aec-85e7-fbc19fb08ef9.jpg",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "58589f14-e572-44ff-9df3-6b9f1e73ef43"
+  },
+  {
+    "url": "https://glif.app",
+    "title": "Glif",
+    "description": "无代码的AI小工具构建平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4ed96ba-e3de-464c-9f6c-433df9ff9d7c.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "2198fb76-5411-41b4-9441-8520114e70ec"
+  },
+  {
+    "url": "https://qimi.com",
+    "title": "奇觅",
+    "description": "美图推出的游戏广告AI制作与投放平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5cb587ba-8f73-4106-b2e5-b16068122e54.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "96ab36b3-a4a7-4816-9493-097ee4e6b246"
+  },
+  {
+    "url": "https://pan.baidu.com/aipan/welcome",
+    "title": "云一朵",
+    "description": "百度网盘最新推出的智能助理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8eedc29f-6dd0-404d-8e9f-eeeb5ac06a66.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "3c8629b9-630c-453f-8c1c-972a495e681d"
+  },
+  {
+    "url": "https://bangong.360.cn",
+    "title": "苏打办公",
+    "description": "360公司推出的一站式AI办公工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/840eae23-e1ae-426a-97d8-1564aee3981b.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "bb298e52-f882-4583-98c3-9dec0e875bab"
+  },
+  {
+    "url": "https://hoarder.app",
+    "title": "Hoarder",
+    "description": "开源的基于AI的书签和个人知识库管理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2fbfb9c9-235e-4706-adc0-1332d859b700.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "89e90a62-ceee-4b93-90f4-dcba0c7f367e"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/xiaomi",
+    "title": "通义晓蜜",
+    "description": "阿里推出的企业智能服务解决方案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ee49bf4-5f8f-4aea-916d-87288cdf6f07.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "8a1473fd-9602-4535-9e31-cc41d16db9c4"
+  },
+  {
+    "url": "https://aiask365.com",
+    "title": "奇妙问",
+    "description": "企业AI数字员工生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3b7121f0-faa4-42d3-94a9-e9bd7c477bb0.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "dfebdd68-25c9-4d28-ad85-db98f6586dc7"
+  },
+  {
+    "url": "https://notebooklm.google",
+    "title": "NotebookLM",
+    "description": "谷歌推出的AI笔记应用，5分钟生成一段对话播客",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/26d2ca6e-635b-48c9-92fc-730845912726.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "25514259-930f-4b2c-b5ba-0a56f92347d5"
+  },
+  {
+    "url": "https://www.yingdao.com/ai-power",
+    "title": "影刀AI Power",
+    "description": "面向企业的无代码AI开发和集成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee6861d5-aa80-4fd4-b5f7-a7ccdad337e6.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "7009ac02-fba1-464d-be7f-64afedcd0149"
+  },
+  {
+    "url": "https://www.tongdaai.com",
+    "title": "通答AI",
+    "description": "企业AI数字员工生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ffa2c5fd-bb89-42e4-bb9b-024a7a1ea6e6.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "080e3121-c219-479e-96e3-be4fff4c5d88"
+  },
+  {
+    "url": "https://smartchoose.cn",
+    "title": "司马诸葛",
+    "description": "企业级AI数字员工平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7a31985e-4f7e-4f55-a6bd-a2924e499c4e.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "5e8c9a8a-8c34-47fc-bfc7-fd70c1ac9b4c"
+  },
+  {
+    "url": "https://www.kaopuai.com",
+    "title": "靠谱AI",
+    "description": "无代码AI机器人创建平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/61481e48-8b89-4a47-ab93-19ecc6764f17.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "9a8a8119-c9fb-425d-8964-e1355f4f1c26"
+  },
+  {
+    "url": "https://www.salesforce.com/einsteincopilot",
+    "title": "Einstein Copilot",
+    "description": "Salesforce推出的CRM系统AI对话助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3c12bbfc-4138-4835-a628-ea8f424661a2.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "5cb75403-cc8f-4edd-8f0a-2bf7e379a60f"
+  },
+  {
+    "url": "https://zapier.com/ai",
+    "title": "Zapier AI",
+    "description": "Zapier推出的AI自动化集成功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0b9c723-dbee-429c-9f54-8e5e0366c4d1.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "09f658c8-982c-450c-b670-674891a03de5"
+  },
+  {
+    "url": "https://www.guaishouai.net",
+    "title": "怪兽AI知识库",
+    "description": "企业知识库大模型 + 智能AI问答机器人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4cbd8c6f-c858-46c9-8c31-02725278a52a.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "d6285f11-74fa-4878-b042-123b7e21242e"
+  },
+  {
+    "url": "https://www.tukuppt.com",
+    "title": "熊猫办公",
+    "description": "AI办公服务平台，提供PPT模板、Excel模板、Word模板等资源",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aa8432a5-8a3c-4ca5-a9e8-d77422966b47.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "aeb2062b-1586-4f89-a1ae-ebf83e28495b"
+  },
+  {
+    "url": "https://ai.eqxiu.com",
+    "title": "小易AI",
+    "description": "易企秀推出的AI办公工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee9ca30c-ac56-459e-b0fb-28ae2c6d1f70.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "28ef8312-c827-4e3d-b8ae-7e0c269ec14c"
+  },
+  {
+    "url": "https://merlin.foyer.work/",
+    "title": "Merlin",
+    "description": "基于ChatGPT的Chrome浏览器扩展，浏览任意网页时利用GPT",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9c063db5-f158-4dae-a9e4-f285e3d005ff.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "d52db46a-557c-421a-ac85-764ab2fdb21f"
+  },
+  {
+    "url": "https://www.raycast.com/ai",
+    "title": "Raycast AI",
+    "description": "Raycast推出的Mac AI助手，智能写作、编程、回答问题等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/730e9380-b2a7-4711-b8cb-8792dbc177ce.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "b5aa4004-fbb2-40d1-b5cf-8e8312503d14"
+  },
+  {
+    "url": "https://timelyapp.com/",
+    "title": "Timely",
+    "description": "AI时间管理跟踪软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/548aece4-3547-4d2c-b053-90a4469d9540.png",
+    "category": [
+      "效能工具"
+    ],
+    "type": "web",
+    "id": "5611953a-4f99-4ed0-a5be-c4bf3077dcef"
+  },
+  {
+    "url": "https://ihuiwa.paluai.com",
+    "title": "绘蛙",
+    "description": "AI电商营销工具，免费生成商品图和种草文案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe86d13d-71ea-43c5-a829-c6b17a8deb40.png",
+    "category": [
+      "图像工具",
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "730d29d2-b049-456e-a7cb-19c5477a6622"
+  },
+  {
+    "url": "https://www.meijian.com/e-commerce",
+    "title": "美间AI",
+    "description": "免费设计工具助手，智能海报、提案和商品图生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/068effba-371f-4e05-a54d-2d33150a8b9f.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "04da8ad1-b5c3-47d1-9529-619924367df2"
+  },
+  {
+    "url": "https://www.gaoding.com",
+    "title": "稿定AI",
+    "description": "一站式设计工具集，免费AI绘图、图片转AI绘画、AI抠图消除",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfabe83e-d50c-410b-be91-e96da7a4553a.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "cc6cfdbe-c07e-49a8-b1c5-660a27b7377f"
+  },
+  {
+    "url": "https://www.recraft.ai",
+    "title": "Recraft AI",
+    "description": "免费无限AI画板，生成高质量矢量艺术画、图标、3D图片和插画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09f908f4-4619-47d2-abfe-946b83d65f7e.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "59454d99-7ec2-4120-8946-14b870837fda"
+  },
+  {
+    "url": "https://www.piccopilot.com/create",
+    "title": "Pic Copilot",
+    "description": "阿里国际推出的AI电商设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8c11807f-e416-42be-a5d1-7f650005bb16.png",
+    "category": [
+      "设计工具",
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "dfade468-ce55-4539-8454-e3436dc605c2"
+  },
+  {
+    "url": "https://aiart.chuangkit.com/matrix",
+    "title": "创客贴AI",
+    "description": "AI辅助的智能在线设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81891aae-6101-454a-80dd-523dda7ec8f1.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "ce9cb362-34a3-433e-8f0e-5066941346bb"
+  },
+  {
+    "url": "https://www.designkit.com/tools",
+    "title": "美图设计室",
+    "description": "AI图像创作和设计平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a9d43c53-8d03-4e20-aac0-60414275d05e.jpg",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "c42ba6d1-93ac-4e3b-b7bc-5c303869a22a"
+  },
+  {
+    "url": "https://www.figma.com/ai",
+    "title": "Figma AI",
+    "description": "Figma推出的原生设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/65f02069-f42d-4397-ba3d-4a8d99800f8e.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "a5aad96b-b266-4034-9314-d41158c83db3"
+  },
+  {
+    "url": "https://idesign.alipay.com",
+    "title": "蚂上有创意",
+    "description": "支付宝推出的设计工具，面向商家提供电商设计服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6d178820-134b-4027-940f-52be153277b3.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "68024488-e45f-4e9c-8aba-ee09f59fd2f1"
+  },
+  {
+    "url": "https://www.isheji.com",
+    "title": "爱设计",
+    "description": "AI在线设计平台，提供多端在线拖拽设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a1234bb-9e02-4cb7-8c84-434a4e90da14.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "8c5cfc9e-263f-49a4-a8b3-5a2f8530372b"
+  },
+  {
+    "url": "https://www.canva.cn/magic",
+    "title": "魔力工作室",
+    "description": "Canva可画推出的一站式AI创作套件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a0a6a9c-3760-4bfd-8a60-0e0094000d7a.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "ef613bcb-6cf4-4fdd-bff3-dd18a8785ca6"
+  },
+  {
+    "url": "https://designer.microsoft.com/",
+    "title": "Microsoft Designer",
+    "description": "微软推出的在线设计海报和宣传图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4bc3baea-fee4-4bd7-8074-a9f9db973683.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "010942fa-ad5a-4dbc-820a-530236150b90"
+  },
+  {
+    "url": "https://onlook.com",
+    "title": "Onlook",
+    "description": "开源AI视觉编辑工具，设计修改自动同步代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ce90d806-55a5-4214-9f3c-dbeb3fa1f5ff.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "76385647-b78c-4890-99cb-0b367b6914fe"
+  },
+  {
+    "url": "https://looka.com/",
+    "title": "Looka",
+    "description": "AI在线设计和生成logo",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1bb8034f-c829-46bd-8a45-036bf3d5abb1.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "2c30eb03-6e95-4bb6-90e0-139728962ae0"
+  },
+  {
+    "url": "https://taishan.qq.com/brand",
+    "title": "智绘设计",
+    "description": "腾讯推出的智能设计平台，让内容更精彩",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8b04865b-056c-4117-a82d-05587bd862e7.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "6443843b-402c-4427-9852-eca372f44282"
+  },
+  {
+    "url": "https://mastergo.com/upcoming-ai/apply",
+    "title": "MasterGo AI",
+    "description": "国产产品设计工具MasterGo推出的智能UI设计助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/caadacd9-a069-4ccd-b569-7fae55cb8ba8.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "639e8858-d3fd-4ed6-a254-8091c7b89391"
+  },
+  {
+    "url": "https://modao.cc/feature/ai.html",
+    "title": "墨刀AI",
+    "description": "墨刀推出的AI产品原型设计助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ae3b1bb0-a4b5-49f4-a68d-9f404f1fc86c.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "f2e5167d-91b5-40ca-acb9-fa8ef665f4cd"
+  },
+  {
+    "url": "https://ibihun.com",
+    "title": "笔魂AI",
+    "description": "设计工具，支持AI抠图、消除、无损放大",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f9b9475e-9404-4d98-ab84-0ae201b55c23.png",
+    "category": [
+      "设计工具",
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "dfa4b91a-4da7-4195-b70e-d09e2b1a3795"
+  },
+  {
+    "url": "https://www.shejijia.com",
+    "title": "居然设计家",
+    "description": "居然之家联合阿里推出的AI家装设计平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84015aa4-f912-410a-a0ca-485690f25199.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "e7d33ad3-6b0c-42bd-8a44-c5e0b68c751b"
+  },
+  {
+    "url": "https://www.figma.com/figjam/ai/",
+    "title": "FigJam AI",
+    "description": "Figma推出的AI白板协作设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/416549c1-d6c4-474c-a43c-81104045216a.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "b667a7d0-4215-42c9-811c-bf115ac4924d"
+  },
+  {
+    "url": "https://luban.aliyun.com",
+    "title": "鹿班",
+    "description": "阿里推出的智能设计商品图和海报的平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96b5b331-b2e5-4278-acf0-c0fe3d9bf4d3.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "9db86e71-a9b1-4a71-a387-25a32632b8b6"
+  },
+  {
+    "url": "https://www.canva.com/magic-design/",
+    "title": "Magic Design",
+    "description": "在线设计工具Canva推出的设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e0f52ac-b040-4e9f-904c-49c554e67acd.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "80bf8c37-c267-491b-a56b-c69b9b4a50b1"
+  },
+  {
+    "url": "https://www.jiandan.link",
+    "title": "简单设计",
+    "description": "免费的在线设计、图片处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5bbf9ae-b2d2-4f9f-9b0e-4948dd40ac2c.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "a06ba857-0f5d-4534-9df9-695f4be6a2c7"
+  },
+  {
+    "url": "https://www.135editor.com/ai_editor",
+    "title": "135 AI排版",
+    "description": "公众号AI图文排版和智能文案生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38e2bd3f-9d33-4287-bdca-a74a358421c9.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "b039410e-faf2-423d-ba54-32581ab0a1cb"
+  },
+  {
+    "url": "https://bigesj.com",
+    "title": "笔格设计",
+    "description": "设计工具合集，包括文生图、智能消除等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e246b055-4c15-4bed-bbfa-ec393e89e6cb.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "01d08ab5-e37e-4b11-9046-1c79024863cd"
+  },
+  {
+    "url": "https://www.logoai.com",
+    "title": "Logoai",
+    "description": "AI LOGO创建设计平台，一站式品牌打造",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f3b33f0-44d6-499c-b43f-953f890a080a.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "e0858f3c-5ab2-4310-9a23-c33b7353eafb"
+  },
+  {
+    "url": "https://www.douhuiai.com",
+    "title": "豆绘AI",
+    "description": "AI绘图设计平台，一键生成720°VR全景图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/98a3785b-bc92-4bde-8edd-05b6da8094b1.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "116869c2-5960-45ab-8516-3366d32ab772"
+  },
+  {
+    "url": "https://www.58pic.com/",
+    "title": "千图网",
+    "description": "在线设计图片素材平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3fb60727-f913-4bce-a583-b050e0218de1.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "af579f42-2b15-4a39-a343-ea195bd04bf1"
+  },
+  {
+    "url": "https://pictographic.io",
+    "title": "Pictographic",
+    "description": "AI插图资源库和生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0cd8a103-3784-42f1-87f2-b63b1cafc592.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "4318d11a-ca8b-4d2d-b36e-d2aea8314e68"
+  },
+  {
+    "url": "https://www.fable.app/prism",
+    "title": "Fable Prism",
+    "description": "AI动效设计和动画效果制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be50d7c8-c2e6-495e-8aaa-ebaca365d532.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "82b83d2a-ece6-430f-a745-7e1aa17c76fa"
+  },
+  {
+    "url": "https://wegic.ai",
+    "title": "Wegic",
+    "description": "AI网页设计和建站开发工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7734da6c-d1cb-48ea-9b4c-336ee22a1f61.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "6ced90ad-b7b8-480a-bc01-f63123e5d79f"
+  },
+  {
+    "url": "https://jiangziai.com",
+    "title": "匠紫",
+    "description": "一站式设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be43426a-467b-4e22-bcc8-c112601f6c77.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "638f4a50-2e2b-4b00-ae70-efbf81f692a2"
+  },
+  {
+    "url": "https://collov.cn",
+    "title": "Collov AI",
+    "description": "AI室内家居设计生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2632a5c-c44c-4052-bfbb-06ebde31af33.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "5c5a5ebe-3811-465b-9719-e9fef06a7755"
+  },
+  {
+    "url": "https://ibaotu.com/tupian/shuziyishu.html",
+    "title": "包图网AI素材库",
+    "description": "包图网提供的特色图库服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/41d2c2cc-edc7-42df-850c-168a87159b38.png",
+    "category": [
+      "设计工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "bc6b5758-570f-4a67-bb66-4e6983001574"
+  },
+  {
+    "url": "https://www.yiketu.com",
+    "title": "易可图",
+    "description": "免费的AI图片编辑和海报设计平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c58ef99b-67b8-4ffb-87e8-44065ad5f30a.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "42cad10a-efc5-489b-aee1-a180f3bae306"
+  },
+  {
+    "url": "https://creatie.ai",
+    "title": "Creatie",
+    "description": "AI驱动的UI和UX设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/512fd938-e8a4-4798-b58d-14fd0834ebd3.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "484e7964-4a15-4639-90ce-18df9e4cb48f"
+  },
+  {
+    "url": "https://www.kittl.com",
+    "title": "Kittl",
+    "description": "AI驱动的平面图形设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8b752d3-a645-4db3-bc89-e1d2ce362d52.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "e6d7f424-85a7-4783-9573-00ec87bc0fbc"
+  },
+  {
+    "url": "https://www.dzine.ai",
+    "title": "Dzine",
+    "description": "一站式AI图像编辑和设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/571ed08b-508f-443d-9f44-a29b914a9f25.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "40eb4768-757b-4570-9809-8bfca6ea5604"
+  },
+  {
+    "url": "https://ilus.ai",
+    "title": "Ilus AI",
+    "description": "AI插画插图生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4f951923-2344-4c46-ad79-eae7bf8defbd.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "bdeff769-f560-4748-af56-e6e31150c32e"
+  },
+  {
+    "url": "https://illustro.app",
+    "title": "Illustro",
+    "description": "AI illustration generator and editor with flat, line art, children's book, and 3D styles",
+    "image": "https://illustro.app/logo/illustro-logo.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "a8f3c2e1-4b5d-4a9e-9c7d-1e2f3a4b5c6d"
+  },
+  {
+    "url": "https://www.kujiale.cn/activities/AI-kujiale",
+    "title": "酷家乐AI",
+    "description": "功能强大的AI家居设计软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e7a7085a-8d59-401c-b208-cf8831cd1715.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "0f94628f-7430-474f-bff0-6467b4743bb8"
+  },
+  {
+    "url": "https://pixso.cn",
+    "title": "Pixso AI",
+    "description": "国产在线设计工具Pixso的内置AI助手，支持AI文生图、AI对话、AI设计等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24a89c9a-6773-4982-a6ff-b739c037a5ad.jpg",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "6b62d695-8957-4ae6-9281-4159fd1d1a8f"
+  },
+  {
+    "url": "https://www.framer.com/ai",
+    "title": "Framer AI",
+    "description": "Framer推出的AI网站自动设计、生成和上线",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bb3cfee-6bf9-4058-9be5-1b7feb8b5463.png",
+    "category": [
+      "设计工具"
+    ],
+    "type": "web",
+    "id": "0da2979a-333c-4cb8-8798-e76e83f04eb2"
+  },
+  {
+    "url": "https://www.trae.com.cn/",
+    "title": "Trae",
+    "description": "字节跳动推出的免费编程工具，基于Claude模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/966a6461-ee44-4f70-8f07-c690db36e115.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "0cdcc48d-23e3-423a-9848-1968ed9350ae"
+  },
+  {
+    "url": "https://click.aliyun.com",
+    "title": "通义灵码",
+    "description": "阿里推出的免费编程工具，基于通义大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/db98f40b-2d4e-463e-a42b-0b4f120bb89d.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "8cf4cfdd-7d85-4af4-9e77-096c8a4cdacb"
+  },
+  {
+    "url": "https://marscode.paluai.com/doubao",
+    "title": "豆包MarsCode",
+    "description": "免费AI编程助手，DeepSeek满血版模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/28f3fd45-f176-4aa9-af0e-a68559b86f85.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "7eac2d73-ca6c-4cff-8806-aadc5380717b"
+  },
+  {
+    "url": "https://comate.baidu.com",
+    "title": "文心快码",
+    "description": "百度推出的AI编程助手，基于文心大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cee71c46-b7b1-48a2-a4a5-9eb35fcc4b68.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "190c0e7d-be03-4307-8d49-dddc8650e20c"
+  },
+  {
+    "url": "https://aws.amazon.com/codewhisperer/",
+    "title": "CodeWhisperer",
+    "description": "亚马逊推出的免费AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51540100-63ca-414f-ac7e-8a3b16f5f5c8.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "56d6efa3-c597-4a86-a53d-ef80bfa81d6b"
+  },
+  {
+    "url": "https://github.com/features/copilot",
+    "title": "GitHub Copilot",
+    "description": "GitHub推出的编程工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7890965-5e65-4aa9-8c08-fb17215d9b1f.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "d6f57600-976a-477f-ac06-9f2c34f9ad74"
+  },
+  {
+    "url": "https://github.com/vostride/agent-qa",
+    "title": "Agent QA",
+    "description": "用自然语言编写、运行和排查网页及移动应用测试，提供 CLI、仪表板和 MCP 服务器",
+    "image": "https://raw.githubusercontent.com/vostride/agent-qa/main/packages/dashboard-ui/public/favicon.svg",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "56adbf4a-0b6a-4baa-8f0f-52ba91a6ef20"
+  },
+  {
+    "url": "https://github.com/Ducksss/codex-profiles",
+    "title": "codex-profiles",
+    "description": "切换命名的 Codex CLI 配置，并在 macOS 上启动具有独立本地状态的 ChatGPT 桌面窗口",
+    "image": "https://raw.githubusercontent.com/Ducksss/codex-profiles/main/media/codex-profile-parallel-instances.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "45a28423-5399-47bc-9ddc-09b36fd00070"
+  },
+  {
+    "url": "https://github.com/ofekron/better-agent",
+    "title": "Better Agent",
+    "description": "本地AI编程代理工作区，统一运行Claude、Codex和Gemini会话，支持并行分叉、任务委派与重启恢复",
+    "image": "https://raw.githubusercontent.com/ofekron/better-agent/dev/frontend/public/icon-512.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "3b0f1f28-7974-4bad-ba6c-1e0b0e9016f2"
+  },
+  {
+    "url": "https://orkas.ai/?source=gh_rvelamen",
+    "title": "Orkas",
+    "description": "开源本地优先的多智能体桌面工作区，支持并行和串行协作",
+    "image": "https://orkas.ai/res/orkas.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "7cbabe24-0a56-42f4-8d82-29064b9b62c1"
+  },
+  {
+    "url": "https://www.doubao.com/chat/coding",
+    "title": "豆包AI编程",
+    "description": "豆包推出的AI编程新功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ec5cd1c0-715d-4875-8153-f969d5c87223.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "1b4528de-51ea-44ef-9882-4375b29c57e3"
+  },
+  {
+    "url": "https://firebase.studio",
+    "title": "Firebase Studio",
+    "description": "谷歌推出的编程工具，一站式开发全栈应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/771fd5e3-fd0f-4f06-8763-7f74c4bad61b.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "074b940d-0151-4794-892b-00c037d89cc1"
+  },
+  {
+    "url": "https://www.cursor.com",
+    "title": "Cursor",
+    "description": "AI代码编辑器，快速进行编程和软件开发",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cdd431c9-1872-4028-8afc-8435b05428fd.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "bd748a83-882a-4ed5-8e77-694354f06492"
+  },
+  {
+    "url": "https://windsurf.com/editor",
+    "title": "Windsurf",
+    "description": "Codeium公司推出的编程工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8faa6817-e1a4-403d-9a75-8b192e33668e.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "396f9d4f-e983-4878-9246-1deab0184f1b"
+  },
+  {
+    "url": "https://bolt.new",
+    "title": "Bolt.new",
+    "description": "StackBlitz 推出的全栈AI代码工具，可以看作 Artfacts、V0 和 Replit 的结合体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/613d2f51-8e7b-4f3e-964e-7d85606a480d.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "4eb4dd8a-a54e-461a-9a7d-41a626fc9851"
+  },
+  {
+    "url": "https://docs.replit.com/replitai/agent",
+    "title": "Replit Agent",
+    "description": "AI初创公司Replit推出的编程工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5148af9e-c97d-40b9-aa86-9063f8208dec.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "a338f6cf-51b9-4d52-b466-eb7ab5f21cc6"
+  },
+  {
+    "url": "https://lovable.dev",
+    "title": "Lovable",
+    "description": "编程工具，用自然对话快速构建网站和Web应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9700e225-86d1-4ead-a393-d70b38121e8d.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "97f2102b-4102-4329-9ee3-ae8626edf9b3"
+  },
+  {
+    "url": "https://www.jetbrains.com/junie",
+    "title": "Junie",
+    "description": "JetBrains 推出的 AI 编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/db807801-bdbb-4721-9b77-6f1a578098b3.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "c7986d9f-e3bc-4480-a861-45218557373a"
+  },
+  {
+    "url": "https://www.xiaohuanxiong.com/code",
+    "title": "代码小浣熊",
+    "description": "商汤科技推出的免费AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/00883842-bdc2-4d08-92a1-0bf3cb48d82c.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "eebea6cd-c2cd-477e-9939-b19770dafde9"
+  },
+  {
+    "url": "https://cloud.tencent.com/product/acc",
+    "title": "腾讯云AI代码助手",
+    "description": "腾讯推出的AI编程辅助工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3a58399d-f0eb-4580-915b-2f8d82ba6909.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "ba388f61-28cf-4f9c-bbe8-81418b3c7e56"
+  },
+  {
+    "url": "https://www.codeium.com/",
+    "title": "Codeium",
+    "description": "免费的编程工具，智能生成和补全代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7026304-8120-4105-a820-e170e1654549.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "ef3ec10b-ff8f-4bdd-a15c-6a52c313f98a"
+  },
+  {
+    "url": "https://codegeex.cn/",
+    "title": "CodeGeeX",
+    "description": "智谱AI推出的免费AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6a8036e-04e2-4e93-be81-5852a5e96f58.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "892fd25a-4cd1-4d22-a1a9-cb0433dca9dd"
+  },
+  {
+    "url": "https://mgx.dev",
+    "title": "MGX",
+    "description": "基于MetaGPT框架的编程工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16207d7e-88c5-42ca-b82c-22769f0c40f0.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "5c38584d-12b2-4380-8cb4-8336b28a3e81"
+  },
+  {
+    "url": "https://sourcegraph.com/cody",
+    "title": "Cody",
+    "description": "Sourcegraph推出的免费编程工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/15120e17-c1e3-4ded-a2d4-f89c81428065.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "b53a840e-07de-4172-903d-3ed11a41e068"
+  },
+  {
+    "url": "https://www.devchat.ai/zh",
+    "title": "DevChat",
+    "description": "开源的支持多款大模型的AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bf7c1e4e-ba6a-4a57-a750-f8841fdd4a28.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "plugin",
+    "id": "1b6a3b2a-995d-4212-8b0d-bb41c0668bf7"
+  },
+  {
+    "url": "https://www.codium.ai/",
+    "title": "CodiumAI",
+    "description": "免费的AI代码测试和分析工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25450e11-edfe-4f83-84b5-8c8eff3e0721.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "c075318f-43c0-4475-a141-0000dd7a183c"
+  },
+  {
+    "url": "https://cosine.sh/genie",
+    "title": "Genie",
+    "description": "Cosine AI推出的AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94146881-a658-4025-9d6d-f98fe1246c04.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "app",
+    "id": "b1e8deee-1c28-4382-9825-e62af9f90a0f"
+  },
+  {
+    "url": "https://www.codeflying.net",
+    "title": "码上飞",
+    "description": "AI软件开发平台，一句话自动生成端到端应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebeafbba-ba0c-41d4-89af-327601bf5873.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "8f589425-30a8-48ed-b030-4ee8e954d9dd"
+  },
+  {
+    "url": "https://iflycode.xfyun.cn",
+    "title": "iFlyCode",
+    "description": "科大讯飞推出的智能编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/115b920d-4db1-4c6e-9d2a-956a3b08a0ac.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "7b359680-edf2-4e8c-aec8-dca1fcafb6ed"
+  },
+  {
+    "url": "https://twinny.dev",
+    "title": "Twinny",
+    "description": "专为 VS Code 设计的AI代码补全插件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/482a2ed9-d4c6-4526-be4e-d465ec5abb37.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "cf8888e6-31f2-41a1-96e5-ec9613bfc2dd"
+  },
+  {
+    "url": "https://idx.dev",
+    "title": "Project IDX",
+    "description": "谷歌推出的AI云端开发和代码编辑器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/74f45092-9dab-4621-a558-e67898f78709.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "a3938327-e416-4604-bda4-3ef828987f49"
+  },
+  {
+    "url": "https://sketch2code.azurewebsites.net/",
+    "title": "Sketch2Code",
+    "description": "微软AI Lab推出的将手绘草图转换成HTML代码工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/44fd3be3-acdb-4566-b72b-269c11cd3694.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "99fdf338-8874-487d-b8aa-9cda39eca34c"
+  },
+  {
+    "url": "https://codefuse.alipay.com",
+    "title": "CodeFuse",
+    "description": "蚂蚁集团推出的AI代码编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2e9193c1-c7ce-4992-a01d-200a3abb0cf9.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "c1dfec13-188b-4872-9d62-f633c55c05c9"
+  },
+  {
+    "url": "https://tabby.tabbyml.com",
+    "title": "Tabby",
+    "description": "免费开源的自托管AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b3555bf1-2f4e-488e-820f-d6f411f73dbe.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "bfcbf4b5-d74f-41fa-81a9-1016c858045d"
+  },
+  {
+    "url": "https://so.csdn.net/chat",
+    "title": "C知道",
+    "description": "CSDN推出的AI技术问答工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff820821-0878-42ff-a43e-989d8c664c17.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "c369d40a-f555-4092-9c31-b0c9bd7fd484"
+  },
+  {
+    "url": "https://coderider.gitlab.cn",
+    "title": "驭码CodeRider",
+    "description": "极狐GitLab推出的AI编程与软件智能研发助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfda4d64-e6cc-42e9-8740-fa09a9d65c97.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "d0973412-2f73-475e-8247-dc9c2c370521"
+  },
+  {
+    "url": "https://about.gitlab.com/gitlab-duo",
+    "title": "Duo Chat",
+    "description": "GitLab推出的AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ee82490e-7732-4a09-8c34-0db793fea039.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "26ae54b6-14f0-4c04-bcfa-7c5dbb1cf38b"
+  },
+  {
+    "url": "https://coderabbit.ai",
+    "title": "CodeRabbit",
+    "description": "AI驱动的代码审查平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff4b3bb1-4db0-4310-82c9-a4596ee9454a.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "a191f2e6-c6e9-4a5e-8af6-fa18fdd9df99"
+  },
+  {
+    "url": "https://www.augmentcode.com",
+    "title": "Augment Code",
+    "description": "AI编程辅助工具，专为大型代码库设计",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ee89e83-6020-497d-8c23-f3188235f5e6.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "d9cb4c3d-7c54-4975-98ad-008492a5b9e9"
+  },
+  {
+    "url": "https://preview.devin.ai",
+    "title": "Devin",
+    "description": "首个全自主的AI软件工程师智能体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84c8822a-d552-4076-b41d-ff5c55e56afa.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "10373bbd-e307-43a9-974c-16baf9dcb8d2"
+  },
+  {
+    "url": "https://plandex.ai",
+    "title": "Plandex",
+    "description": "免费开源的基于终端的AI编程引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/57c2b0e2-77ad-45e9-bbad-0e1c2b8dc028.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "7f372293-7131-4ef5-8396-cafb1ae44aea"
+  },
+  {
+    "url": "https://terminallylazy.github.io/Tree-Ring-Memory/",
+    "title": "Tree Ring Memory",
+    "description": "本地优先的AI智能体记忆生命周期层，提供Rust CLI/TUI、SQLite/FTS召回、审计、遗忘和整合",
+    "image": "https://raw.githubusercontent.com/TerminallyLazy/Tree-Ring-Memory/main/assets/tree-ring-memory-logo.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "248ff3e8-e6b3-41f1-a380-acb6ad91c412"
+  },
+  {
+    "url": "https://code.fittentech.com",
+    "title": "Fitten Code",
+    "description": "非十科技推出的免费AI代码助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd95c49b-64a6-4656-ae9f-439ccc5ee932.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "b8250077-ceee-4ae6-b10e-37330dcbb9f7"
+  },
+  {
+    "url": "https://www.useblackbox.io",
+    "title": "BLACKBOX AI",
+    "description": "黑箱AI编程助理，快速代码生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/75ceb4ef-2412-422d-85ad-7b22038c1354.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "f7f6aa1d-7cfc-43ec-bc53-c1a60f3b39b4"
+  },
+  {
+    "url": "https://soloist.ai",
+    "title": "Solo",
+    "description": "Mozilla推出的零编程无代码AI网站建设工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/425f3b0d-761e-4195-9c94-fd649037a9c2.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "4c3e0784-1dcf-4da0-bd41-4d4168eab58d"
+  },
+  {
+    "url": "https://www.jetbrains.com/ai",
+    "title": "JetBrains AI",
+    "description": "JetBrains推出的AI编程开发助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c26235c-672b-4af6-b209-7a22aae356b7.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "d4bf96d2-b95d-4716-af2d-49e2783b6369"
+  },
+  {
+    "url": "https://www.huaweicloud.com/product/codeartside/snap.html",
+    "title": "CodeArts Snap",
+    "description": "华为云推出的智能编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/45255887-9403-482b-b4f8-75d069bba302.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "551efb95-f82b-4f73-b237-78a046eace41"
+  },
+  {
+    "url": "https://www.askcodi.com/",
+    "title": "AskCodi",
+    "description": "你的个人AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/acc514d6-e282-461f-ae7d-f0f59f462882.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "1abc30e3-d130-4cb8-980d-ca1e6cc06fbe"
+  },
+  {
+    "url": "https://v0.dev",
+    "title": "v0.dev",
+    "description": "AI生成前端React/UI组件，由Vercel推出",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac8e35f5-84aa-4a57-8250-e86f501455d1.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "36acacb6-84b2-42f6-bdc6-f6783d716813"
+  },
+  {
+    "url": "https://robloxguimaker.dev/",
+    "title": "Roblox GUI Maker",
+    "description": "输入提示词生成Roblox Studio GUI布局和Lua入门代码",
+    "image": "https://robloxguimaker.dev/images/roblox-gui-maker-og.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "9d95814e-cf0a-4a40-8a9f-6dad1515801b"
+  },
+  {
+    "url": "https://codesandbox.io/blog/meet-boxy-ai-coding-assistant",
+    "title": "Boxy",
+    "description": "CodeSandbox推出的AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b68b3b8a-3bf5-4bd3-b68b-268b11eead4a.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "46cbc21d-244a-4e21-a202-7e5d0ed1a2b9"
+  },
+  {
+    "url": "https://www.quest.ai",
+    "title": "Quest AI",
+    "description": "AI将设计稿生成React代码，支持JavaScript和TypeScript",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8c1af342-af5e-4551-84b5-eb71d2bb49af.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "5cb3c841-450e-4a11-a32a-7d5f6dd8fb11"
+  },
+  {
+    "url": "https://sky-code.singularity-ai.com/index.html#/",
+    "title": "天工智码Skycode",
+    "description": "AI智能编程助手，轻松生成各种代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1aa9833e-7085-4523-972a-c3d1eb569c3d.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "4e82d30b-7064-4c34-b012-278e1a38d493"
+  },
+  {
+    "url": "https://jam.dev/jamgpt",
+    "title": "JamGPT",
+    "description": "AI Debug调试助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bdf3ea8e-03cb-4b3a-894a-f66095a1324f.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "9292a800-c814-4f9d-a3ab-01f8f6a63f7b"
+  },
+  {
+    "url": "https://www.aixcoder.com",
+    "title": "aiXcoder",
+    "description": "自然语言到代码的方法级代码生成，以及多行智能代码补全",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4703158-7bc4-44ff-a54e-ee9ffa50f5ca.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "28df4c78-5b94-45d9-82de-5b26d64fcc9c"
+  },
+  {
+    "url": "https://www.airops.com/",
+    "title": "AirOps",
+    "description": "AI SQL语句生成和修改",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edbd9f93-1c81-4298-a06c-0566cbf93e0d.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "429d57ae-3949-4b9d-83aa-d2385560298b"
+  },
+  {
+    "url": "https://www.imgcook.com/",
+    "title": "Imgcook",
+    "description": "阿里推出的免费设计稿智能生成前端代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/437a7d9a-0cf5-4f54-989e-aaaf365d17f2.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "96b1180c-e2c7-4890-8598-b82674a8801b"
+  },
+  {
+    "url": "https://ling-deco.jd.com/",
+    "title": "Deco",
+    "description": "京东推出的设计稿一键生成多端代码工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fbd2deb8-1a05-42b0-bf0c-a62afd26cd46.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "6ab82dc5-57ab-48a0-b38d-86841e0c4b11"
+  },
+  {
+    "url": "https://replit.com/site/ghostwriter",
+    "title": "Ghostwriter",
+    "description": "知名在线编程IDE Replit推出的AI编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/29068b5f-a268-4aa0-8ef3-fe23633d8fd2.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "ce77448e-d2fd-4ba3-99f7-c5c29492b4a6"
+  },
+  {
+    "url": "https://www.codiga.io/",
+    "title": "Codiga",
+    "description": "AI代码实时分析",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/369a7e85-7978-40a0-b168-e5a25e8ba78c.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "82c67f0c-de1f-4110-ac0b-f8e83293b77e"
+  },
+  {
+    "url": "https://www.locofy.ai/",
+    "title": "Locofy",
+    "description": "AI无代码工具将Figma、Adobe XD和Sketch设计转换成前端代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6cb6033-0379-4aec-9234-0e094d9d54a3.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "0400d965-93ff-46b7-92b0-cd089e2fc814"
+  },
+  {
+    "url": "https://fronty.com/",
+    "title": "Fronty",
+    "description": "AI智能将图片转换成HTML和CSS代码",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e098eb1a-9c06-443e-b466-d16d43256aae.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "d2bcf1f0-7279-4b6e-970b-fee37b98a20d"
+  },
+  {
+    "url": "https://www.marsx.dev/",
+    "title": "MarsX",
+    "description": "AI无代码软件开发",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c762c06f-9cec-4fb1-89e0-0381c13cd9df.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "3020404a-1517-412c-b430-b79afde0abfd"
+  },
+  {
+    "url": "https://www.tabnine.com/",
+    "title": "Tabnine",
+    "description": "AI代码自动补全编程助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/78595e7e-3032-4266-b4ca-a19245c554f0.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "f6001343-0d25-47c1-9c2e-33e923d62ad4"
+  },
+  {
+    "url": "https://mutable.ai/",
+    "title": "Mutable AI",
+    "description": "人工智能加速软件开发",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09c58371-8210-479b-b515-f525c3d9aae9.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "e607fbe3-23ee-437b-adc7-292ac6d25ee2"
+  },
+  {
+    "url": "https://debuild.app/",
+    "title": "Debuild",
+    "description": "低代码快速开发网页应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f3a7d51c-8d96-49f1-b0dd-7bfc54475caa.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "1d26a8a5-4375-453f-b247-027389fa1571"
+  },
+  {
+    "url": "https://www.warp.dev/",
+    "title": "Warp",
+    "description": "21世纪的终端工具（内置AI命令搜索）",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4d809132-3ff6-42e0-a4cb-2be8a541a377.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "63994934-d13e-4e45-a551-5d312e480738"
+  },
+  {
+    "url": "https://fig.io/",
+    "title": "Fig",
+    "description": "下一代命令行工具（内置AI终端命令自动补全）",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20e03366-537b-482c-8105-cf23087a4e0b.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "33c0e7db-b20b-4a6f-b7e8-aa5b1e06616e"
+  },
+  {
+    "url": "https://codesnippets.ai/",
+    "title": "CodeSnippets",
+    "description": "AI代码生成、补全、分析、重构和调试",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6a40963b-23c2-4c1b-877e-166d92224ee9.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "27846e6a-f0d2-495c-b4d8-335cc224f022"
+  },
+  {
+    "url": "https://hocoos.com/",
+    "title": "Hocoos",
+    "description": "无代码AI智能在线快速创建网站",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f708ec99-37be-4ff3-b608-be24096c0c5c.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "f259b580-113a-4dd9-ab07-a2a8a3ed6dd7"
+  },
+  {
+    "url": "https://httpie.io/ai",
+    "title": "HTTPie AI",
+    "description": "AI API开发工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/15f18c12-cfab-492f-8f1f-26d3cb2d4c0f.gif",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "6ee1430a-04a9-4ccd-8796-78013e9a3349"
+  },
+  {
+    "url": "https://xquik.com/en",
+    "title": "Xquik",
+    "description": "面向开发者的X自动化平台，提供REST API、webhooks和MCP服务",
+    "image": "https://xquik.com/icon.svg",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "b603a1c9-6a95-484c-a81e-57a5691a89cc"
+  },
+  {
+    "url": "https://ai-code-reviewer.com/",
+    "title": "AI Code Reviewer",
+    "description": "AI代码检查",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d2fb69f-a103-4edb-a626-e38a44190521.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "46a4cab4-33e9-4105-916e-bbc01b848246"
+  },
+  {
+    "url": "https://visualstudio.microsoft.com/zh-hans/services/intellicode/",
+    "title": "Visual Studio IntelliCode",
+    "description": "Visual Studio AI辅助开发",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43877041-7644-4724-b221-92a21cab3e56.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "003450ab-f143-4775-bfc8-237f6b07fe1a"
+  },
+  {
+    "url": "https://www.heycli.com/",
+    "title": "HeyCLI",
+    "description": "自然语言转义为CLI命令",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1a252933-efa3-424d-a398-c316cdbfd35f.png",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "663cc20f-5118-4a55-ba23-9cb093c63aec"
+  },
+  {
+    "url": "https://teamorouter.com?utm_source=github&utm_medium=issue&utm_campaign=round3&utm_content=awesome-ai-tools-cn",
+    "title": "TeamoRouter",
+    "description": "面向 AI 编程工具的 LLM API 智能路由网关，一个 Key 接入 Claude/GPT/Gemini/DeepSeek，实时路由优化成本，微信支付宝充值",
+    "image": "https://teamorouter.com/favicon.ico",
+    "category": [
+      "编程工具"
+    ],
+    "type": "web",
+    "id": "860737f6-e036-438e-87f6-2e963e5f402a"
+  },
+  {
+    "url": "https://www.promptingguide.ai/zh",
+    "title": "提示工程指南",
+    "description": "提示工程指南（Prompt Engine...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5a66705-f50b-4151-abd2-c7139dc39079.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "bfc10e55-4a1e-4b0c-ac70-07e1cc1dcb67"
+  },
+  {
+    "url": "https://promptperfect.jinaai.cn",
+    "title": "PromptPerfect",
+    "description": "PromptPerfect 是一款专业好...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c621588-9c2a-4f66-9fc0-b9a37bf1e4cd.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "99954922-faca-4fac-89d5-50d17462ee28"
+  },
+  {
+    "url": "https://flowgpt.com/",
+    "title": "FlowGPT",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c148e62-c1d5-4a93-9d6f-0dae82657a1c.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "8f718ce0-ae2b-47f3-bf6a-3582e6546d8d"
+  },
+  {
+    "url": "https://openart.ai/promptbook",
+    "title": "Stable Diffusion Prompt Book",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bbe09e8e-df67-4b8e-9e21-b79228f6263a.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "847f97b1-912d-46b4-a551-7bd1442a58bd"
+  },
+  {
+    "url": "https://prompthero.com/",
+    "title": "PromptHero",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef876c2c-98cf-4489-aa10-4f97d4a8737a.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "dc5db75a-9d51-4642-85d3-436775224278"
+  },
+  {
+    "url": "https://www.clickprompt.org/zh-CN/",
+    "title": "ClickPrompt",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51f613e6-46fc-4680-8625-5d020beb3984.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "1cc0b932-2a50-4e75-b29b-c503216a9ea9"
+  },
+  {
+    "url": "https://www.aipromptgenerator.net/zh",
+    "title": "AI Prompt Generator",
+    "description": "AI Prompt Generator是什么 A...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/19fecdbf-806f-4ae5-b50f-18d1c5681ee1.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "59b48314-1a80-47ab-adb4-10c5401e6fa4"
+  },
+  {
+    "url": "https://www.aishort.top/",
+    "title": "AI Short",
+    "description": "AI Short是什么 AI Short是一...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ef7d9bbf-522b-4408-b9be-2f6243158f30.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "bac26f0c-2f8e-482b-baaf-01c75eac7c30"
+  },
+  {
+    "url": "https://github.com/langgptai/LangGPT",
+    "title": "LangGPT",
+    "description": "LangGPT是什么 LangGPT是一种...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7849766d-ea76-4231-90ba-1211b62fa6ca.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "08a77423-ff32-4b37-8b9c-2db027eb3246"
+  },
+  {
+    "url": "https://generrated.com/",
+    "title": "Generrated",
+    "description": "当你第一次开始使用DALL•E 2...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3d9bc78c-69f7-4b83-8810-de888a8ae551.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "9f226c4d-5c13-4d4f-b52f-bd6de2f9204b"
+  },
+  {
+    "url": "https://publicprompts.art/",
+    "title": "PublicPrompts",
+    "description": "PublicPrompts是什么 PublicP...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/208bda49-5a09-4512-9f67-20864c33e9b0.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "de565b02-1344-4a10-acbf-ccc709af9a89"
+  },
+  {
+    "url": "https://snackprompt.com/",
+    "title": "Snack Prompt",
+    "description": "输入正确的提示词，可以让Cha...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5871bbd9-1189-4268-a878-b8bccf5ad4a3.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "047a9177-071a-4078-a62c-e83aacd105f2"
+  },
+  {
+    "url": "https://www.aiprm.com/",
+    "title": "AIPRM",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a4f8a112-d003-4e55-952a-3da702124520.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "516d121e-102a-466d-a0f5-ba302756ab7c"
+  },
+  {
+    "url": "https://www.ai016.com/",
+    "title": "绘AI",
+    "description": "绘AI致力于探索和创造一种全...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/987fcf60-7aa4-4101-bfa9-55296d40c57e.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "012f0d70-c1d3-4798-b8de-421866cc9cdc"
+  },
+  {
+    "url": "https://prompt.noonshot.com/",
+    "title": "MJ Prompt Tool",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/130a5cc0-112f-4bf7-9aa1-92b9c9548cfe.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "c162425f-6bb7-4c13-b707-9e9366b8e897"
+  },
+  {
+    "url": "https://tools.saxifrage.xyz/prompt",
+    "title": "Visual Prompt Builder",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4fec661-d06a-468b-a566-0dad1b88c73a.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "505bad89-6175-4ccd-9ca2-c51fbfccf493"
+  },
+  {
+    "url": "https://github.com/benf2004/ChatGPT-Prompt-Genius",
+    "title": "ChatGPT Prompt Genius",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d826544b-360f-44dc-b03a-8dd327f3038d.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "eefc6d37-e358-4030-8204-3e982ce04c87"
+  },
+  {
+    "url": "https://promptbase.com",
+    "title": "PromptBase",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4c3bf232-d1e3-4f03-a661-639c9f349d87.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "3bc7ac0a-3531-4953-80ab-6f4daf18b8e1"
+  },
+  {
+    "url": "https://promptvine.com/",
+    "title": "PromptVine",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8d9b5e65-fbdc-40c3-ab4e-b85bf82f447b.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "85dd1cf3-97db-4bcb-a361-0327fcbb09f5"
+  },
+  {
+    "url": "https://prompts.chat/",
+    "title": "Awesome ChatGPT Prompts",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b669210-5770-48f2-adbc-9d9d46aac294.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "1ef445f9-8719-4cde-8d08-9c45c2407488"
+  },
+  {
+    "url": "https://learningprompt.wiki/",
+    "title": "Learning Prompt",
+    "description": "",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3fd7f440-73ad-4bfe-a2e4-f430afec5152.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "c2a09ca3-aacf-42c4-8991-14e0e6c18072"
+  },
+  {
+    "url": "https://www.aishort.top/",
+    "title": "ChatGPT Shortcut",
+    "description": "ChatGPT Shortcut是国内开发...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/04f64d60-c5a3-4fdd-8a9f-88c0fd7b4360.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "206fe2c5-c207-4b2d-8482-dc78ed081998"
+  },
+  {
+    "url": "https://icihun.com",
+    "title": "词魂",
+    "description": "词魂是一个AIGC精品提示词库...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c532a025-6d1b-401e-b3dd-b72db748d22d.png",
+    "category": [
+      "提示词工程"
+    ],
+    "type": "web",
+    "id": "7eab4efb-3363-47b3-ba54-b2aedf43070d"
+  },
+  {
+    "url": "https://www.chineselaw.com/tyjs/index",
+    "title": "元典智库",
+    "description": "智能法律知识服务平台和搜索引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d2a2480b-3dca-47c6-a927-690c49188b0e.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "4cfc9f94-0dbf-4e53-883d-8595b67e83f7"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/farui",
+    "title": "通义法睿",
+    "description": "阿里推出的免费AI法律顾问助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bf7a0785-7d3d-4c65-9720-7dfaab0bbc4a.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "7baa0f73-efa0-4018-a6e0-1b0e37cd32ac"
+  },
+  {
+    "url": "https://ailegal.baidu.com/",
+    "title": "法行宝",
+    "description": "百度推出的免费AI法律助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4b5f539-0a6a-4177-aade-7126e819a716.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "3d03db02-075b-40b1-9427-a92d2c428490"
+  },
+  {
+    "url": "https://chatlaw.cloud/lawchat/",
+    "title": "ChatLaw",
+    "description": "北大开源的法律大模型和助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/72e3dfb6-1bc4-460f-93f9-9fe549920347.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "e6e93d4a-6f65-49df-9def-eebf7fec4e26"
+  },
+  {
+    "url": "https://www.delilegal.com/search",
+    "title": "得理法搜",
+    "description": "AI法律智能检索系统",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dc079f8a-6c37-470e-86c5-1cd33d43293c.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "df2bba37-7efe-44e8-9afe-45252e56c708"
+  },
+  {
+    "url": "https://www.fazhi.law",
+    "title": "法智",
+    "description": "同花顺推出的AI法律助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6e1a1f1-7705-4a64-be8b-ebeecce0a8bb.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "c92dbd78-056a-4041-a1ec-774a49f7b8f0"
+  },
+  {
+    "url": "https://www.hairuilegal.com",
+    "title": "海瑞智法",
+    "description": "一站式AI法律咨询助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3bc50cc9-5293-4a3c-85c6-63bfd03c45ac.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "9ee641af-3149-4780-aacd-d549048fa648"
+  },
+  {
+    "url": "https://contract.yoo-ai.com",
+    "title": "合同嗖嗖",
+    "description": "专业的AI法律合同生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6977cdb-b12c-4849-aa86-600dc870c19e.png",
+    "category": [
+      "法律助手"
+    ],
+    "type": "web",
+    "id": "2440f4eb-ca0d-4263-a5d4-5b3dd20d565f"
+  },
+  {
+    "url": "https://tusiart.com",
+    "title": "吐司AI",
+    "description": "AI绘画模型社区和在线生图平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81e13040-90df-46ba-8623-048843cd7369.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "a1ebb334-0564-4832-9b9c-8e79dff0a3da"
+  },
+  {
+    "url": "https://www.meijian.com/mj-box/ai-pic-matting-intro",
+    "title": "美间AI抠图",
+    "description": "美间AI推出的免费智能抠图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/369fee83-d774-4349-9931-46e9a9ea8dd3.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2e86d99f-b1d9-439e-bc52-a2bf9476347d"
+  },
+  {
+    "url": "https://jimeng.jianying.com/ai-tool/home",
+    "title": "即梦",
+    "description": "抖音旗下免费AI图片创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/198938d4-35e3-4847-ab1e-915d889f3764.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "74a58f79-749f-4f54-a00b-c797eabbf8df"
+  },
+  {
+    "url": "https://abeiai.com",
+    "title": "阿贝智能",
+    "description": "一站式AI绘本创作平台，副业变现必备",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/16aab08c-f473-41e5-9ba9-01a8904baf49.jpg",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "9d1ffb0d-b27c-48c0-8265-bc844e8742ea"
+  },
+  {
+    "url": "https://www.midjourney.com/home",
+    "title": "Midjourney",
+    "description": "AI图像和插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c9b60cca-2928-4142-9edb-c6527c226925.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "75fa4b9b-e2aa-49c8-869e-25c526088e47"
+  },
+  {
+    "url": "https://artistrylab.net",
+    "title": "炉米Lumi",
+    "description": "字节跳动推出的AIGC图像创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e103d39d-cf3e-46b5-8604-365451fbc5cb.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "677356f8-4195-4a0a-a939-493fb21a9f9a"
+  },
+  {
+    "url": "https://civitai.com/",
+    "title": "Civitai",
+    "description": "免费的AI图像绘画作品和模型分享平台和社区",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c5832324-5e91-4853-a545-14c3e0b456d8.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "18e84982-edde-4cb2-a0fb-452b8ea6c8a2"
+  },
+  {
+    "url": "https://d.design",
+    "title": "堆友AI反应堆",
+    "description": "阿里旗下堆友推出的多风格AI绘画生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/deab4051-0ca4-44e9-bbee-075177c74127.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2f760fa9-0a6e-4223-a79d-017b96c8a64a"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/wanxiang",
+    "title": "通义万相",
+    "description": "阿里最新推出的AI绘画创作模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/101e3689-82b7-495e-bdb7-3517874c30c1.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "6d970382-9e6d-4e2b-94c2-a059cde1b796"
+  },
+  {
+    "url": "https://miaohua.sensetime.com/inspiration",
+    "title": "秒画",
+    "description": "商汤科技推出的免费AI作画和图片生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21d29027-e561-451d-9b30-38b4869c4218.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "1efa15a7-dbdd-4023-9ac7-57e054527402"
+  },
+  {
+    "url": "https://www.whee.com/",
+    "title": "WHEE",
+    "description": "美图推出的AI图片和绘画创作生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fdc93d6f-7af6-4585-8b96-17e0f5b1dd36.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "b77d20bd-dabb-4fe3-bf9b-238f6201e752"
+  },
+  {
+    "url": "https://www.liblib.art",
+    "title": "LiblibAI·哩布哩布AI",
+    "description": "国内领先的AI图像创作平台和模型分享社区",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0cb06aed-3b9e-4b51-a265-df6b2f2616e8.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "d8443898-711f-4d97-902d-8619c86acc80"
+  },
+  {
+    "url": "https://design.meitu.com/aigc/text-to-image",
+    "title": "美图AI文生图",
+    "description": "美图推出的AI文本生成图片的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d0c0493-78f3-4d8a-a0c8-d3925c8aae63.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "083d2679-3b39-4a47-9eb3-9d792cb2226b"
+  },
+  {
+    "url": "https://www.qiyuai.net",
+    "title": "奇域AI",
+    "description": "中式审美国风AI绘画创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/603997f0-fb8d-4534-9465-bb3ca696f822.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "6feb04d5-1b3d-4fd4-888f-bf8698e067e6"
+  },
+  {
+    "url": "https://klingai.kuaishou.com",
+    "title": "可灵AI",
+    "description": "快手推出的AI图像和视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c372fb3a-b500-4dea-b36f-4759a55a2af9.png",
+    "category": [
+      "图像工具",
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "b99c47cc-fffa-4b9f-bdee-b4bad5be7917"
+  },
+  {
+    "url": "https://img.logosc.cn",
+    "title": "AI改图神器",
+    "description": "AI万能图片在线编辑器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d4318c88-7e73-432d-8fea-748f93c38cd2.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "b11d8106-3bf3-4624-a6a2-6e822b553233"
+  },
+  {
+    "url": "https://www.krea.ai",
+    "title": "Krea AI",
+    "description": "实时AI图像、视频生成和编辑平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/68f29c6e-dd38-4cfa-895a-65244d021463.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "afbcb903-e083-400b-998b-dbf7adadc0ce"
+  },
+  {
+    "url": "https://raoedits.top/",
+    "title": "Rao Edits",
+    "description": "浏览器端AI图像生成和参考图编辑工具，可用于社交视觉、产品图和创意工作流",
+    "image": "https://raoedits.top/preview.webp",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "131c9656-f7f9-403d-a30c-b3f0ca944e48"
+  },
+  {
+    "url": "https://yingtu.ai/en",
+    "title": "YingTu",
+    "description": "浏览器端 AI 图像与视频路由测试平台，支持提示词、参考图、尺寸与下载结果对比",
+    "image": "https://yingtu.ai/og-image.jpg",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "fca2ad49-bb18-43cb-a244-36d003314de9"
+  },
+  {
+    "url": "https://www.photoroom.com/zh",
+    "title": "Photoroom",
+    "description": "在线AI图片编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb98ebb9-8362-4e92-8973-0e41e17220e0.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "5da2f82d-5212-4033-bdab-0af6ea2457f3"
+  },
+  {
+    "url": "https://www.gohairwow.com",
+    "title": "HairWow",
+    "description": "AI发型试戴和护发建议工具，支持预览发型、发色、刘海、层次和胡须造型",
+    "image": "https://www.gohairwow.com/assets/images/logo/favicon.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "3c5d3ca0-2e1f-4d46-b601-f7b7b3c08a8f"
+  },
+  {
+    "url": "https://ribbet.ai/",
+    "title": "Ribbet.ai",
+    "description": "免费的多功能AI图片处理工具箱",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c615d791-d360-45fc-bec3-828e57636bd0.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "2b8cdfd8-7638-41e0-921d-5dc65a9ac507"
+  },
+  {
+    "url": "https://agi.taobao.com",
+    "title": "万相营造",
+    "description": "阿里旗下推出的多模态AI创意生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e92779dc-4728-4003-aaaf-334d0a9499e9.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "01a98341-048b-4fd2-affe-ceb428a118c9"
+  },
+  {
+    "url": "https://www.photosir.com",
+    "title": "悟空图像PhotoSir",
+    "description": "新一代专业图像处理软件，更智能、更高效、更好用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/752a7abc-5b96-49b8-8a07-e8b6bdd6d3d3.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "987e2eb9-5d7c-4b3b-93ae-3aa5eb8f7d26"
+  },
+  {
+    "url": "https://chacha.so.com/home",
+    "title": "360智图",
+    "description": "360推出的AI作图平台，支持智能抠图、智能消除、智能放大、智能配图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/821332b2-7eb5-472d-92b0-92ab84509b6f.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "ee9aaef9-fabb-4b60-abd7-85205aa9fda8"
+  },
+  {
+    "url": "https://www.pixcakeai.com",
+    "title": "像素蛋糕",
+    "description": "像甜科技推出的AI图像后期软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/73d0dac0-8b01-473b-ab49-54885a501c3f.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "bdb41c97-7ff5-4a9e-951f-a1b26178decd"
+  },
+  {
+    "url": "https://www.remove.bg/zh",
+    "title": "remove.bg",
+    "description": "强大的AI图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3e54dff-f24e-43cd-88d3-922672ce2858.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "5944122a-3ed3-4615-a815-ce2a9cf094b8"
+  },
+  {
+    "url": "https://ifshot.com",
+    "title": "如果相机",
+    "description": "仅需1张照片，快速生成AI写真照片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89475663-cb48-4bc0-aca8-c58970f52dbf.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "8a1f2a9c-0fc5-4d32-b787-f917ac016354"
+  },
+  {
+    "url": "https://arc.tencent.com/zh/ai-demos/",
+    "title": "ARC",
+    "description": "腾讯旗下ARC实验室推出的免费AI图片处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/531b38d4-fab1-4ba9-bba7-37e8a19a1890.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "407e1b2f-501f-448a-96fe-3734dfc18bae"
+  },
+  {
+    "url": "https://www.cutout.pro/",
+    "title": "Cutout.Pro",
+    "description": "AI在线处理图片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d6247e6f-13bb-4b0a-96a4-b50bc6811872.png",
+    "category": [
+      "图像工具",
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "fb4d2889-9322-4153-9e6b-175d57bc7656"
+  },
+  {
+    "url": "https://magicstudio.com/zh",
+    "title": "MagicStudio",
+    "description": "高颜值AI图像处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ed484c65-dc8d-4621-8dde-a26752426416.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "866c1425-1735-408d-a82f-571391a090b3"
+  },
+  {
+    "url": "https://booltool.boolv.tech/home",
+    "title": "Booltool",
+    "description": "在线AI图像工具箱",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/81512f9a-18cb-4653-90d9-7d9a03903434.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "f91ca075-59bf-4f52-a702-e262800c7ed4"
+  },
+  {
+    "url": "https://faceswapper.ai",
+    "title": "Faceswapper",
+    "description": "AI在线换脸工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89470c97-7544-4e4a-9b58-090a355eef1f.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "31ab004d-d758-49ec-a0db-264cf61be5d5"
+  },
+  {
+    "url": "https://clipdrop.co/",
+    "title": "ClipDrop",
+    "description": "Stability.ai推出的AI图片处理系列工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d6f6683-0f07-4045-94a7-2ffebe5df505.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "36eae13c-d151-47dc-b2a6-f47f9960ee5c"
+  },
+  {
+    "url": "https://vmake.ai",
+    "title": "Vmake AI",
+    "description": "AI在线图像和视频编辑平台，专为电商、设计提供服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/530fc329-ab4d-464f-96c3-f41b23616ff1.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "e27d4c5f-e540-4877-bdc0-539cccf1a71c"
+  },
+  {
+    "url": "https://app.leonardo.ai/auth/login",
+    "title": "Leonardo.ai",
+    "description": "免费的AI绘画和图像生成工具和社区",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94e7f68b-f1de-4cef-a8e5-37b3067f80b3.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "6abb3fcf-5dcc-4396-9516-8056e18013e7"
+  },
+  {
+    "url": "https://www.deepswapper.com",
+    "title": "DeepSwapper",
+    "description": "免费的在线AI换脸工具，支持图片、视频多种格式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/101a8b0b-5e13-48bc-b89d-7e335e105d28.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "69bd59c9-f5d8-4d8e-9a1e-9dd192af872c"
+  },
+  {
+    "url": "https://www.kacha.ai/zh",
+    "title": "Kacha AI",
+    "description": "专业的AI写真工具，媲美专业摄影",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/43449d3f-45ca-43a3-bd2b-afc590a9137b.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "1dd3915e-1a87-4879-83b9-510bb597e2de"
+  },
+  {
+    "url": "https://www.pictech.cc",
+    "title": "PicTech AI",
+    "description": "免费的在线图片翻译工具，支持一键抠图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dbd43314-f6bd-4ecb-a386-c3fbc605fd29.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "93afe91c-160d-439f-8e8c-878bebb083e0"
+  },
+  {
+    "url": "https://hotpot.ai",
+    "title": "Hotpot.ai",
+    "description": "AI图片图像处理和生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9baee105-3eb4-47d9-b18b-852eb6b9b283.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "a3e1435c-ecc8-4fe3-ab85-ff78ff400eb7"
+  },
+  {
+    "url": "https://www.icongen.io",
+    "title": "IconGen",
+    "description": "免费的icon图标AI生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25e9e922-6a44-4ecd-b9fa-3300a1818b18.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "894af4ff-8f07-4bd6-81fd-e655d90aae35"
+  },
+  {
+    "url": "https://paint.mobvoi.com",
+    "title": "言之画",
+    "description": "AI图像内容创作平台，由出门问问推出",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c7eed531-3370-4a9d-afa3-051a024c833e.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "f9235eaa-a18f-422c-84b4-4fa967808fdf"
+  },
+  {
+    "url": "https://yinian.cloud.baidu.com/creativity/main/workbench",
+    "title": "百度智能云一念",
+    "description": "基于百度文心大模型的多模态内容创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e9e2bd08-79da-4411-b7d1-3afda24db1e2.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "cd7181a9-df1c-4db4-bb31-104a5b770338"
+  },
+  {
+    "url": "https://www.aiyou.art",
+    "title": "艾绘",
+    "description": "一键创作故事、绘画、配音，轻松创建高质量的绘本故事",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e218c8c1-0d8f-4731-b1f5-e2b39b5b667e.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "0216356f-4727-4e8a-9909-b9541eb1ef1c"
+  },
+  {
+    "url": "https://www.diffus.graviti.com",
+    "title": "Graviti Diffus",
+    "description": "开箱即用的 Stable Diffusion WebUI 在线图像生成服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cd334579-93f9-4f7c-89ca-437b1805e804.png",
+    "category": [
+      "图像工具"
+    ],
+    "type": "web",
+    "id": "7d19ea08-022a-437f-aee6-a66e4626195c"
+  },
+  {
+    "url": "https://acgnai.art",
+    "title": "触手AI绘画",
+    "description": "免费专业的AI绘画/模型/分享平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89373daf-f46b-4844-9b49-025de2d594cf.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "87dcbf22-3cb7-4241-8e16-f9b701305657"
+  },
+  {
+    "url": "https://yige.baidu.com/",
+    "title": "文心一格",
+    "description": "AI艺术和创意辅助平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5cb951c2-5709-46b8-bd42-ba2a9d3afc3d.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "e12d0de5-2f77-4752-9f8d-a957fc80e414"
+  },
+  {
+    "url": "https://zmrj.art",
+    "title": "造梦日记",
+    "description": "AI一下，妙笔生画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cc7657df-023f-4519-9de0-34de9e7863e0.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2bbec84d-429d-4017-943f-27f89006a3c6"
+  },
+  {
+    "url": "https://www.canva.com/ai-assistant/",
+    "title": "Canva AI图像生成",
+    "description": "在线设计工具Canva推出的AI图像生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/56f60e90-60e3-40dd-8caa-cc05f9ad0055.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "c8435fdc-d73e-40a8-b804-0c6d9d8ab14c"
+  },
+  {
+    "url": "https://photo.baidu.com/photasy/home",
+    "title": "超能画布",
+    "description": "百度网盘推出的AI创意图像写真创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2106e45f-925a-4844-98fc-495e564ca2b7.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "77770542-92c4-44e0-a1c1-3bdfa65d74d1"
+  },
+  {
+    "url": "https://www.adobe.com/products/firefly.html",
+    "title": "Adobe Firefly",
+    "description": "Adobe最新推出的AI图片生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/918d9acf-5103-4522-9e89-d6030015f224.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "fb0b42b6-02ad-4595-9023-af2c2abcc5fb"
+  },
+  {
+    "url": "https://ai.sohu.com/search",
+    "title": "简单AI",
+    "description": "搜狐最新推出的AI图片生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fd1784ac-19cc-45c5-ba6e-2d28c7b7063a.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "7c423ffd-2102-45d2-8f02-46a265acf4c6"
+  },
+  {
+    "url": "https://maliang.mthreads.com",
+    "title": "摩笔马良",
+    "description": "摩尔线程推出的AI图像绘画创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f2b5a3bd-4d37-4c97-9f8e-86d6e413982b.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "213f3d80-1329-417c-aa36-9e6d3ef26568"
+  },
+  {
+    "url": "https://exactly.ai",
+    "title": "Exactly.ai",
+    "description": "专业的AI绘画和艺术创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/edc091e6-f5d0-4958-9a07-337263a72009.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "45865501-6729-4e4e-9523-bec9d1ad00e8"
+  },
+  {
+    "url": "https://creator.nolibox.com",
+    "title": "画宇宙",
+    "description": "人工智能AI作画网站",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5a9b8feb-9455-4a09-8d83-0d82907074e3.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "f4eb4cb7-d107-4753-ae6c-051319b3cb2c"
+  },
+  {
+    "url": "https://6pen.art",
+    "title": "6pen Art",
+    "description": "面包多团队推出的从文本描述生成绘画艺术作品",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/beb9b5e1-bee9-43d3-9772-949d850b3564.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "7b363d92-88ee-4064-b86d-21807e923e91"
+  },
+  {
+    "url": "https://aiart.chuangkit.com/landingpage",
+    "title": "创客贴AI画匠",
+    "description": "创客贴推出的AI艺术画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6b6e146-13d5-40f2-8772-702d57af21b8.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "aa6f6fd7-29f9-40f4-864d-aa7c4920e2b6"
+  },
+  {
+    "url": "https://visualelectric.com/",
+    "title": "Visual Electric",
+    "description": "专业的高质量AI图像创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da34d3d7-ae3f-44fe-a6a2-58b060955424.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "68e022dc-34d3-40b3-9062-28e55c0e4840"
+  },
+  {
+    "url": "https://aigc.360.com",
+    "title": "360智绘",
+    "description": "360推出的AI图片和绘画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ea74e78-6df2-4e59-83df-2fad1f1a71fd.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "f3a1b65b-6b23-4f5b-9005-ebb91eb695e0"
+  },
+  {
+    "url": "https://ke.study.163.com/artWorks/painting",
+    "title": "网易AI创意工坊",
+    "description": "网易云课堂推出的AI作画平台，在线使用Stable Diffusion出图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/056ba9ac-a8aa-438f-92ca-294962b4adfc.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "9fb5d3a8-dd54-4252-88ac-137157d91273"
+  },
+  {
+    "url": "https://www.meta.com/ja-jp/help/artificial-intelligence",
+    "title": "Imagine with Meta",
+    "description": "Meta最新推出的在线AI图像生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2db41fd8-efe9-4698-81a5-68ac4c3d0e11.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "28a5537f-3dad-49e4-982c-6c008cb80b36"
+  },
+  {
+    "url": "https://www.freepik.com/ai/image-generator",
+    "title": "Freepik AI Image Generator",
+    "description": "Freepik最新推出的AI图片生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7fc0085e-b462-446c-ae1c-f682b72fd399.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "7885055a-6564-402b-b87d-3f1b1132cff7"
+  },
+  {
+    "url": "https://stockimg.ai/",
+    "title": "Stockimg AI",
+    "description": "AI生成各种类型的图像和插画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f118a473-f74b-4fac-bba3-8975e8f4c8e1.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2e2eb223-5bd7-42c9-91a5-a12d346cd7c0"
+  },
+  {
+    "url": "https://clipdrop.co/stable-doodle",
+    "title": "Stable Doodle",
+    "description": "StabilityAI最新推出的将手绘草图转换成精美图像的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e84e43f-666e-4c6e-a98f-7045b18bae1b.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "3bccba87-822a-47bf-835e-c600bb9dfde8"
+  },
+  {
+    "url": "https://175.fun",
+    "title": "175FUN",
+    "description": "免费AI绘画社区，国货之光",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7f20259e-afff-4b39-b7e9-b02376586889.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "991ef037-6b3f-4d5d-add6-c20afdf180d7"
+  },
+  {
+    "url": "https://xingzheai.cn/#create",
+    "title": "行者AI美术",
+    "description": "AI图片生成和美术创作工具箱",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f9dcbf8-fbdf-4207-b739-3f78da0a4876.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "e6638898-4b27-4082-8bb8-ed983c268f3e"
+  },
+  {
+    "url": "https://skybox.blockadelabs.com",
+    "title": "Skybox AI",
+    "description": "AI生成和合成360°全景图像插画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b8f06286-38aa-45cd-8db9-141958a3db38.png",
+    "category": [
+      "图像工具",
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "fb04d0c1-6e1f-4d7a-8d5c-06ab8f122f6f"
+  },
+  {
+    "url": "https://facet.ai/",
+    "title": "Facet",
+    "description": "AI图片修图和优化工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c70c4343-a11c-4e19-ad16-7f1648b2e0e1.png",
+    "category": [
+      "图像工具",
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "e48c123e-1c04-4d3e-81bc-870e082c386e"
+  },
+  {
+    "url": "https://clipdrop.co/relight",
+    "title": "Relight",
+    "description": "ClipDrop推出的AI图像打光工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c0d35cc5-b04b-49af-8714-b179cc7d9b7e.png",
+    "category": [
+      "图像工具",
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "36b61e9c-8983-41d6-92d9-c773130bcd0f"
+  },
+  {
+    "url": "https://www.upscayl.org/",
+    "title": "Upscayl",
+    "description": "免费开源的AI图片无损放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/afd4f758-5a55-4e45-a28f-f9e06d6b9045.png",
+    "category": [
+      "图像工具",
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "7fff6d21-8395-475b-b63b-cd6ff412d8c7"
+  },
+  {
+    "url": "https://qianlu.cc",
+    "title": "千鹿AI",
+    "description": "AI设计助手，每日可免费生成300张图像",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ceade445-ac5d-4dc0-88c7-e6fa3e3b4489.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2fb60490-4e47-4c59-b2b6-1dcd639e8df5"
+  },
+  {
+    "url": "https://www.xingliu.art",
+    "title": "星流AI",
+    "description": "LiblibAI推出的一站式AI图像生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/02a07503-79e9-4efe-aba3-b9d34bf4d4b8.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "5ffc7782-309f-41be-b361-8750275a6713"
+  },
+  {
+    "url": "https://www.youchuan.cn",
+    "title": "悠船",
+    "description": "Midjourney官方推出的中文版AI图像生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38bd79d4-402a-42a2-9323-591e001c8350.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "d698ec8d-ca26-4c14-aa4d-7e96ee7ea06a"
+  },
+  {
+    "url": "https://www.ishencai.com",
+    "title": "神采",
+    "description": "让创意照进现实， AI生成创意插画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/804e0329-6a84-493c-9eea-748c45c16a0c.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "6add0f0e-ed46-47be-8856-44ef6826d456"
+  },
+  {
+    "url": "https://sky-paint.singularity-ai.com/index.html#/",
+    "title": "天工巧绘SkyPaint",
+    "description": "免费的AI插画绘制工具，由昆仑万维与奇点智源合作推出",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fcf4dc04-2ca2-4f78-9c98-6be6c73c64ae.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "db912bfd-e003-4c11-bc5d-09ee5affcccf"
+  },
+  {
+    "url": "https://flagstudio.baai.ac.cn/",
+    "title": "FlagStudio",
+    "description": "智源研究院推出的AI文本图像绘画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/73eb6459-b52f-49ba-b342-19883198acce.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "18092ebd-b2f4-4bf7-9329-9796f0912f34"
+  },
+  {
+    "url": "https://nightcafe.studio/collections",
+    "title": "NightCafe",
+    "description": "AI艺术插画在线生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2a6eaf5d-8b17-4bec-9f12-1e5f701a7103.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "3dcd7383-4192-44b5-a1ab-040ae201e4cd"
+  },
+  {
+    "url": "https://nijijourney.com",
+    "title": "niji・journey",
+    "description": "魔法般的二次元绘画生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9b79a9b1-e19e-4096-9621-b4fc5815df74.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "80ff96bf-c965-4d91-b9e2-429051e1447f"
+  },
+  {
+    "url": "https://deepdreamgenerator.com/",
+    "title": "Deep Dream Generator",
+    "description": "AI创建生成梦幻般的插画图片，刻画你的梦中场景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/647e0020-7c3d-4f9b-9ad7-e83b8213e2ab.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "7e17eca7-391c-4dfb-989a-fb8b9dee6aa4"
+  },
+  {
+    "url": "https://588ku.com/ai/wuxianhua/Home",
+    "title": "无限画",
+    "description": "千库网推出的AI图片插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84b273bb-5ca3-4f27-a394-64cc9d64fbb6.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "36de2987-cf80-4c84-bfee-53fa9c91c0a0"
+  },
+  {
+    "url": "https://www.bluewillow.ai/",
+    "title": "BlueWillow",
+    "description": "免费的AI图像艺术画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/11657a45-3218-42c0-867f-9a19794cf8c3.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "9686e644-e1f0-4ce2-9954-914f5a2c7b9f"
+  },
+  {
+    "url": "https://waifulabs.com/",
+    "title": "Waifu Labs",
+    "description": "免费在线AI生成二次元动漫头像",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/58510acb-878b-4512-8b24-1db6f3cd05a3.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "1c610a3b-9c11-4df5-b906-9c902fdb2ba7"
+  },
+  {
+    "url": "https://dreamlike.art/",
+    "title": "dreamlike.art",
+    "description": "免费在线插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bbf9d84a-2ddb-4ba9-944c-b7ea5dca06c4.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "ff48dd42-c553-402e-ab24-0b9f92c21880"
+  },
+  {
+    "url": "https://www.artbreeder.com/",
+    "title": "Artbreeder",
+    "description": "创建令人惊叹的插画和艺术",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/41c377f0-6bf7-4a77-8337-38ec6de8082d.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "b1a92c3a-80bf-4f8f-99ff-f290f7545318"
+  },
+  {
+    "url": "https://www.tiamat.world",
+    "title": "Tiamat",
+    "description": "国内团队推出的AI艺术画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0a6f505-850b-4dc0-a560-e6747ff5809b.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "75fd3b29-03ac-49b6-96ec-c38c7befc5da"
+  },
+  {
+    "url": "https://vegaai.net/",
+    "title": "Vega AI",
+    "description": "在线免费AI插画创作平台，支持文生图，图生图，条件生图等多种绘画模式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/be723419-719c-42ef-8fdf-da94e0cb7070.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "f8707c39-fd08-434a-9f4d-2041ef69f1a1"
+  },
+  {
+    "url": "https://deepgram.com/ai-apps/craiyon",
+    "title": "Craiyon",
+    "description": "免费在线文本到图像生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/591c3fc0-f19e-4206-9b88-ecdb0fa5ce54.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "4814935c-8064-4623-b2a4-b62363f0856d"
+  },
+  {
+    "url": "https://aigc.wondershare.cn/",
+    "title": "万兴爱画",
+    "description": "万兴科技推出的AI生成高品质艺术画工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/132d439d-5bdf-4c14-aa77-e3a03fa1da7d.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "588fbcc7-a356-4106-b4e2-fd5a98a643c6"
+  },
+  {
+    "url": "https://photosonic.pro/",
+    "title": "Photosonic",
+    "description": "Writesonic推出的AI艺术插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a1d09db-f334-4793-ab3b-eb6827cd3b2e.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "1796f9ae-76d5-4fec-8d42-8a2b55b57031"
+  },
+  {
+    "url": "https://astria.us.com/",
+    "title": "Astria",
+    "description": "可定制的人工智能图像生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ef3796a-21f6-4453-8e73-d5f2966e299f.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2f6d6989-6ed6-4982-b05d-ccac6918829e"
+  },
+  {
+    "url": "https://getimg.ai/",
+    "title": "getimg.ai",
+    "description": "在线AI图像和插画创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/029d4c77-f0f6-48ce-ac0e-a4001a837132.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "fe0e5ca6-ab67-42c5-a376-b31e41ec564d"
+  },
+  {
+    "url": "https://www.dreamup.com",
+    "title": "DreamUp",
+    "description": "DeviantArt推出的AI插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/725be852-b91c-42db-9350-3d1e6aa36bf2.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "c20497f2-2439-4377-9d8b-45cd6012e3eb"
+  },
+  {
+    "url": "https://scribblediffusion.net/",
+    "title": "Scribble Diffusion",
+    "description": "将草图转变为精美的插画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6b23c0c1-f64c-4d0d-a725-25abdffe6eff.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "da28968e-8be1-4bf9-9656-638ea96b2cac"
+  },
+  {
+    "url": "https://lexica.art/",
+    "title": "Lexica",
+    "description": "基于Stable Diffusion的在线插画生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b42ec681-1bf9-4c21-bda7-7cd1942b6b4e.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "38549360-9fb5-4604-b613-deebdd39f345"
+  },
+  {
+    "url": "https://picsart.com/ai-image-generator/",
+    "title": "Picsart AI",
+    "description": "Picsart推出的AI图片生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a7fe2986-dd4d-4ef6-8277-8d56edaac582.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "aea480b0-7af5-4bed-b051-8f91408c403e"
+  },
+  {
+    "url": "https://completeaitraining.com/ai-tools/neural-love/",
+    "title": "neural.love",
+    "description": "AI艺术图片生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a6761d7-8bc0-4430-ae2a-b257e69bbacc.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "a818d2c5-b060-4a8c-b10f-f4be91ff5b08"
+  },
+  {
+    "url": "https://faq.starryai.com",
+    "title": "starryai",
+    "description": "AI艺术图片生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f970cc2-25fd-441c-95c2-cb635611f513.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "94d9463d-b711-4fe9-be9f-7a09278ee4bc"
+  },
+  {
+    "url": "https://www.artsy.net/",
+    "title": "Artssy",
+    "description": "AI图像生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ffba2bc-5e2c-4bb9-906d-f49e0b71ae9f.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "8b56978f-9e3f-41db-a6e4-29abd7369b51"
+  },
+  {
+    "url": "https://www.playform.io/",
+    "title": "Playform",
+    "description": "专业的高质量AI艺术画生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c8f26b7e-b3f7-4525-ac23-bf187b4806a1.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "2a69d677-5b51-4548-9f5b-3b0e98144941"
+  },
+  {
+    "url": "https://cn.bing.com/images/search?q=photo+booth+by+magic+studio&qpvt=Photo+Booth+by+Magic+Studio&FORM=IGRE",
+    "title": "Photo Booth by Magic Studio",
+    "description": "AI创建个人资料图片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2658f484-0441-4267-87c8-a21b6a196404.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "4b1969a9-f8d9-4b79-bdc1-766a1e9de66a"
+  },
+  {
+    "url": "https://supermeme.ai/",
+    "title": "Supermeme",
+    "description": "AI MEME梗图生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e11bb5a7-8da1-46a9-a47f-8451d39eb2bb.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "17ccc371-38cf-4439-94ce-1bc863b20aa5"
+  },
+  {
+    "url": "https://www.fotor.com/features/ai-image-generator/",
+    "title": "Fotor",
+    "description": "Fotor推出的在线AI图片生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c103578f-890a-47ac-9dd7-ec5660192f54.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "254560a4-d700-4ab7-b768-bf8c1443e26b"
+  },
+  {
+    "url": "https://help.dream.ai/hc/en-us",
+    "title": "Dream.ai",
+    "description": "WOMBO推出的AI艺术画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efa7fa4d-ce52-4730-a84e-2ecceded8450.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "d10f52d2-21e7-45ca-8ec5-ec5f02c91e3c"
+  },
+  {
+    "url": "https://www.wujieai.com",
+    "title": "无界AI",
+    "description": "AI生成艺术插画和二次元人物",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/375f8fae-b0ec-4153-af67-405e2fa199f3.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "bfc9dc96-8ac1-472f-bc69-03af4e532ead"
+  },
+  {
+    "url": "https://www.zcool.com.cn/ailab",
+    "title": "站酷梦笔",
+    "description": "国内知名设计社区站酷推出的人工智能插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/738bbcac-ea75-44ed-a450-fb0d943d8f46.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "aa067d4a-024a-4076-b116-74db282fa361"
+  },
+  {
+    "url": "https://www.gaituya.com/aiimg/",
+    "title": "改图鸭AI图片生成",
+    "description": "改图鸭AI图片生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/320e8cd6-0234-4a98-bb99-a087cbef7870.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "b59d9435-b852-45d4-aac7-17c1e05042c8"
+  },
+  {
+    "url": "https://prodia.com/",
+    "title": "Prodia",
+    "description": "AI艺术画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96b0903d-2d31-4bbf-ad2e-47bba346913c.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "074578c7-3f0e-49a1-95ca-39d07191ae73"
+  },
+  {
+    "url": "https://lucidpic.com/ai-stock-photo-generator",
+    "title": "Lucidpic",
+    "description": "AI生成高质量人像照片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e4b7bd73-0dd0-4f01-b733-1738a017b8e8.png",
+    "category": [
+      "图片插画生成"
+    ],
+    "type": "web",
+    "id": "ff67da0d-ec3b-45ea-89f5-5078d10dff53"
+  },
+  {
+    "url": "https://tusiart.com/template/807760005523577813",
+    "title": "吐司AI抠图",
+    "description": "吐司AI推出的智能抠图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a037d356-6c72-45cc-8c2d-8d0fb338e1bf.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "74ab5c2d-7ac4-49ed-ad61-060689b7c412"
+  },
+  {
+    "url": "https://cutout.designkit.com",
+    "title": "美图抠图",
+    "description": "美图秀秀推出的AI智能抠图工具，一键移除背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dfee7b65-7f59-4d88-aa4c-ae6ff25595dd.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "8c5c8d3d-49aa-472b-bb9c-939c8fbe1eb4"
+  },
+  {
+    "url": "https://www.gaoding.com",
+    "title": "稿定AI抠图",
+    "description": "AI自动去水印、消除背景工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/84603ee7-09ae-4b4c-a240-85c6fce6c418.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "fee03b1d-03d5-456d-9ce2-8aad68c4e793"
+  },
+  {
+    "url": "https://www.piccopilot.com/create",
+    "title": "Pic Copilot AI抠图",
+    "description": "Pic Copilot推出的AI抠图工具，支持批量抠图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/907398a5-51cd-443d-9113-24d04b82282a.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "ceece106-1bd9-46ad-8e6f-3999c464dd98"
+  },
+  {
+    "url": "https://kt.94xy.com",
+    "title": "鲜艺AI抠图",
+    "description": "免费AI抠图工具，支持离线安装使用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b27a8a41-8746-46db-af66-7c7da72e74c4.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "f64a5dfd-79a5-490c-ab14-d6b027eb991d"
+  },
+  {
+    "url": "https://pixian.ai",
+    "title": "Pixian.AI",
+    "description": "免费的AI图片背景抠除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7af2966f-f6e2-47cd-8ef3-c94981099bc8.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "c3ddfbc4-a358-413a-b956-c83d3b88467c"
+  },
+  {
+    "url": "https://d.design/toolbox/cutout",
+    "title": "顽兔抠图",
+    "description": "阿里推出的一键去除商品图背景工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e1e95609-fe20-44e3-99b4-94cf394e29dd.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "54116d91-fe8e-48ea-a08c-2d57ace3a135"
+  },
+  {
+    "url": "https://icons8.com/bgremover",
+    "title": "Icons8 Background Remover",
+    "description": "Icons8出品的免费图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/866d5b8a-bb68-433d-b562-bbcf1bbf92fa.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "7f4b12a8-a2b6-4419-85c9-d5133fe8c3d7"
+  },
+  {
+    "url": "https://bgsub.cn/",
+    "title": "BgSub",
+    "description": "免费的保护隐私的AI图片背景去除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3ee90cc8-2d99-468a-a356-7e3f5fa55bb9.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "3d5002c6-5f85-4280-bffa-66406b8ebba6"
+  },
+  {
+    "url": "https://clipdrop.co/remove-background",
+    "title": "ClipDrop Remove Background",
+    "description": "ClipDrop出品的AI图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1768ed02-c244-42fd-ae9f-f01bef1cc5b3.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "016a61df-ad2f-416e-9b00-7216cb211b2c"
+  },
+  {
+    "url": "https://www.erase.bg/zh",
+    "title": "Erase.bg",
+    "description": "在线抠图和去除图片背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e327996f-4702-41ae-ba87-0e8c10845e80.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "4b331576-e036-43ee-a3d0-34963675da3b"
+  },
+  {
+    "url": "https://hisheai.com",
+    "title": "千图设计室AI助手",
+    "description": "AI绘画抠图工具集",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b6a79abf-0486-4ea9-bb48-cf5e0e7313d7.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "300e741c-e226-464e-a9c6-016fcbdf35f0"
+  },
+  {
+    "url": "https://www.adobe.com/express/feature/image/remove-background",
+    "title": "Adobe Image Background Remover",
+    "description": "Adobe Express的图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d7ad478e-354b-48fe-b82c-c94b0efca313.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "1fc41712-0a75-432a-b221-f62d772c107a"
+  },
+  {
+    "url": "https://removal.ai/",
+    "title": "Removal.AI",
+    "description": "AI图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dbc60e3b-18ee-4bd0-ba0c-e50a77ffb3b0.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "67752ae4-47c5-4fdc-85f1-0636594a389e"
+  },
+  {
+    "url": "https://magicstudio.com/zh/backgrounderaser",
+    "title": "Background Eraser",
+    "description": "AI自动删除图片背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1e149fb7-7f41-480d-af6c-c5670f7c8564.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "b7b2a9b4-a0a9-47bb-bc0a-52640cd5d8d0"
+  },
+  {
+    "url": "https://www.slazzer.com/",
+    "title": "Slazzer",
+    "description": "免费在线抠除图片背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0ab5ce42-2976-4432-84ac-b28c9efaa1c0.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "1d582c40-a009-4893-a057-7d668e87f733"
+  },
+  {
+    "url": "https://www.cutout.pro/zh-cn/remove-background",
+    "title": "Cutout.Pro抠图",
+    "description": "AI批量抠图去背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ee659df-964f-4ef7-a148-7b9213b0bcc0.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "7078150e-9be7-48bf-8c8e-a1e37c0e1957"
+  },
+  {
+    "url": "https://bgremover.vanceai.com/",
+    "title": "BGremover",
+    "description": "Vance AI推出的图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/87dcff6b-74ab-428c-a4f9-0b1becbd9cba.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "9b6edf65-9775-4c61-9c7d-01cee7335d5a"
+  },
+  {
+    "url": "https://tools.picsart.com/image/background-remover/",
+    "title": "Quicktools Background Remover",
+    "description": "Picsart旗下的Quicktools推出的图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fd455ddb-9d02-4e72-a36f-b9439803a056.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "80127029-b798-42a9-99f1-63db11382d8e"
+  },
+  {
+    "url": "https://zyro.com/tools/image-background-remover",
+    "title": "Zyro AI Background Remover",
+    "description": "Zyro推出的AI图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2ed676c3-935e-4002-82c9-1223327de5a5.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "ccf07240-ff65-48db-a3a7-dbcbdb960174"
+  },
+  {
+    "url": "https://photoscissors.com/",
+    "title": "PhotoScissors",
+    "description": "免费自动图片背景去除",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24346910-14dd-407f-9c19-82a3bd6f95fd.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "e07c8b60-8e69-4c6d-8d3c-7d709d6e0be6"
+  },
+  {
+    "url": "https://www.yijiankoutu.com/",
+    "title": "一键抠图",
+    "description": "在线一键抠图换背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4ceace52-b9a3-4498-a418-1312a097ff2f.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "5a3d6f45-7e17-4564-ab98-6ed4cf384a07"
+  },
+  {
+    "url": "https://clippingmagic.com/",
+    "title": "ClippingMagic",
+    "description": "魔术般地去除图片背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/89f0e0b5-6b62-43c0-b495-d80a6c1b8347.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "0198c11d-f0e0-4d8b-ace6-571a5afbdcad"
+  },
+  {
+    "url": "https://www.tukeli.net/",
+    "title": "图可丽",
+    "description": "AI图片和视频抠图，一键抠图神器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/784de0e2-46c5-4a9d-9925-90f4e9d16e0d.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "58b1d07c-9b55-458a-b62b-c0a00bbf451b"
+  },
+  {
+    "url": "https://hotpot.ai/remove-background",
+    "title": "Hotpot AI Background Remover",
+    "description": "Hotpot.ai推出的图片背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/652fd440-2169-40bd-b94c-9fb75eee0c65.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "d1641303-cfd0-485c-8a3c-d4a9e02d53d4"
+  },
+  {
+    "url": "https://www.stylized.ai/",
+    "title": "Stylized",
+    "description": "AI产品图背景替换",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/793e4d2b-49eb-4d29-992e-af9fa6ea68fd.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "db5696d3-7fbe-4442-a286-b890a2bad544"
+  },
+  {
+    "url": "https://www.booth.ai/",
+    "title": "Booth.ai",
+    "description": "高质量AI产品展示效果图生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b1b60d8-31ff-417a-8173-67afce0ea697.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "91862734-46ab-48d3-ba17-ee18f41643a7"
+  },
+  {
+    "url": "https://www.pixelcut.ai/",
+    "title": "Pixelcut.ai",
+    "description": "AI产品背景移除和替换",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0a09f6bb-2e55-4041-85bd-014f319f23a6.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "e29170ca-089a-4e9d-84b1-7a31aaa62613"
+  },
+  {
+    "url": "https://picwish.com/",
+    "title": "PicWish",
+    "description": "AI图片编辑和背景移除",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14e763e6-40e1-4cbe-8cce-d9b2f90dbe46.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "ca00c45d-5be5-474b-a18b-de5167dfde86"
+  },
+  {
+    "url": "https://www.photoroom.com/zh",
+    "title": "PhotoRoom",
+    "description": "免费的AI图片背景移除和添加",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/03318867-955c-4ef6-9463-22ccade8460e.png",
+    "category": [
+      "背景消除"
+    ],
+    "type": "web",
+    "id": "241694fc-aad8-45ad-99ef-a15e915168bf"
+  },
+  {
+    "url": "https://icons8.com/goprod",
+    "title": "GoProd",
+    "description": "Icons8推出的智能图片背景移除和无损放大二合一Mac应用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01ef023a-ac19-481b-99d4-f4ee6c35dd18.png",
+    "category": [
+      "背景消除",
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "683b53ea-565a-4ac5-8c58-70d416dc311f"
+  },
+  {
+    "url": "https://tusiart.com/template/820721890405622530",
+    "title": "吐司AI高清",
+    "description": "吐司AI推出的图片变高清/修复工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79141565-d1d9-4724-ae46-01d2ed88e858.png",
+    "category": [
+      "图片无损放大",
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "493a8f6b-f4c1-45a4-ac2d-1bc7b12beab3"
+  },
+  {
+    "url": "https://www.meijian.com/mj-box/ai-pic-zoom-intro",
+    "title": "美间AI无损放大",
+    "description": "免费的AI图片放大、变清晰工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01879bd5-1f19-475f-9773-46ff4c2821ed.png",
+    "category": [
+      "图片无损放大",
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "facba1ff-4a94-41a2-ba60-5d5da528d898"
+  },
+  {
+    "url": "https://www.designkit.com/upscale",
+    "title": "美图无损放大",
+    "description": "美图设计室推出的AI图片变清晰工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24733e5e-9743-4996-8e48-0a1db6334295.jpg",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "3710ef68-1dcc-4bba-9e2c-7c221324a905"
+  },
+  {
+    "url": "https://bigjpg.com/",
+    "title": "BigJPG",
+    "description": "免费的在线图片无损放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac3641d4-4876-4579-b38f-6c013d3d0bcd.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "e91329f6-2b42-4e8e-9cf8-f734ba830c77"
+  },
+  {
+    "url": "https://mejorarimagen.org",
+    "title": "Mejorar Imagen",
+    "description": "AI图像放大增强工具，快速放大至10倍或12K分辨率",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/44f352ed-e566-4373-a562-9c6f2357a81a.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "cb8a2242-5aac-4779-9031-cb72b8dc24ad"
+  },
+  {
+    "url": "https://magnific.ai",
+    "title": "Magnific AI",
+    "description": "强大的AI图像放大工具，最高支持到10K分辨率",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/60deee4b-2dc7-43c3-a4cb-54b89dd5c54f.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "32b152d7-30ae-4221-920b-ea25a289c468"
+  },
+  {
+    "url": "https://letsenhance.io",
+    "title": "Let’s Enhance",
+    "description": "AI在线免费放大图片并保持图像质量",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/79f934bf-5bfb-44d3-8fb9-b1dfe539b90c.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "c47b4d5d-3748-449f-a360-f18de2430881"
+  },
+  {
+    "url": "https://icons8.com/upscaler",
+    "title": "Icons8 Smart Upscaler",
+    "description": "Icons8出品的AI图片无损放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/544e5ca3-9b8b-41b3-ba9b-7d67271c3a4d.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "ee658661-0839-478c-b5bc-cc6a07e2ec47"
+  },
+  {
+    "url": "https://clipdrop.co/image-upscaler",
+    "title": "ClipDrop Image Upscaler",
+    "description": "ClipDrop出品的AI图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d4a6b50-170f-471e-8aed-1af19ca7276b.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "7ecde005-8336-477a-ab82-2e80d0948dfb"
+  },
+  {
+    "url": "https://imgupscaler.com/",
+    "title": "Img.Upscaler",
+    "description": "免费的AI图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d0b2321-751a-4976-a2e8-76433cbeaefe.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "616832c8-d133-46a0-b876-238a49170d67"
+  },
+  {
+    "url": "https://www.fotor.com/image-upscaler/",
+    "title": "Fotor AI Image Upscaler",
+    "description": "Fotor推出的AI图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3439d6cd-e90a-492a-9da6-f1d071922347.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "83ce9680-dfe8-4456-853d-bd765d4c65f2"
+  },
+  {
+    "url": "https://zyro.com/tools/image-upscaler",
+    "title": "Zyro AI Image Upscaler",
+    "description": "Zyro出品的人工智能图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/21902e02-66cd-4bf6-ae8d-1b990fe3ccf9.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "eba8ebce-1336-4b24-a1b6-878ab7b4e7f8"
+  },
+  {
+    "url": "https://www.media.io/image-upscaler.html",
+    "title": "Media.io AI Image Upscaler",
+    "description": "Media.io推出的AI图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fbf86bd9-811e-4f9c-88d0-eb6f3a01c109.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "6e753f93-11ee-4b90-9449-09314098d2c7"
+  },
+  {
+    "url": "https://www.upscale.media/zh",
+    "title": "Upscale.media",
+    "description": "AI图片放大和分辨率修改",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9a3741d7-f0c9-485f-abec-6b6ac5befdef.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "60575492-f710-43fe-8657-96c47258b0e2"
+  },
+  {
+    "url": "https://ai.nero.com/image-upscaler",
+    "title": "Nero Image Upscaler",
+    "description": "AI免费图片无损放大",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff7efcca-e518-41e0-82f5-fe5cd85118fe.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "0493412c-58db-445e-9fe0-491f583ecfeb"
+  },
+  {
+    "url": "https://vanceai.com/image-resizer/",
+    "title": "VanceAI Image Resizer",
+    "description": "VanceAI推出的在线图片尺寸调整工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8902355d-a7d9-4d8d-a4bb-ad74faf7a85a.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "2dea4a88-bbf0-44a0-9dd8-0017df3e2ed5"
+  },
+  {
+    "url": "https://photoaid.com/en/tools/ai-image-enlarger",
+    "title": "PhotoAid Image Upscaler",
+    "description": "PhotoAid出品的免费在线人工智能图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/956ff2cd-53f5-43cd-b6b9-ec76ea16d6da.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "341f6e44-4f1d-40f8-9136-77dae4c67911"
+  },
+  {
+    "url": "https://upscalepics.com/",
+    "title": "Upscalepics",
+    "description": "在线图片放大工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/809ef8f2-43a6-4602-8b66-c10013198b04.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "14d1c948-f3a9-4e62-8262-c8ded9ef8290"
+  },
+  {
+    "url": "https://magicstudio.com/zh/enlarger",
+    "title": "Image Enlarger",
+    "description": "AI无损放大图片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac47aa1a-0bb6-445a-9766-cd6fa373a409.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "45ec8858-7f7c-4b9b-9822-f57def3c211f"
+  },
+  {
+    "url": "https://pixelhunter.io/",
+    "title": "Pixelhunter",
+    "description": "AI智能调整图片尺寸用于社交媒体平台发帖",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/35b0ca71-bf69-44b2-a44e-c507633fcd76.png",
+    "category": [
+      "图片无损放大"
+    ],
+    "type": "web",
+    "id": "37aab609-7a5e-4b03-8519-9728603eb025"
+  },
+  {
+    "url": "https://yunxiu.meitu.com/",
+    "title": "美图云修",
+    "description": "美图秀秀推出的一站式AI智能修图软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/23176d46-3732-4023-ad3b-70c09b64dadd.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "f07f786f-f1f5-4036-9f9f-3ba9a085b3ae"
+  },
+  {
+    "url": "https://remini.ai",
+    "title": "Remini",
+    "description": "AI智能将模糊照片变高清的图像修复工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3b625362-35a0-4f1e-927a-475e97b3f343.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "a8a1270b-2f70-46ba-965f-3f2af59b119c"
+  },
+  {
+    "url": "https://jpghd.com/zh",
+    "title": "jpgHD",
+    "description": "人工智能老照片上色和修复",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/91766c12-337b-42f4-8a53-164aa8729166.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "5297f888-5c1c-46ab-b796-e25b3eee44b3"
+  },
+  {
+    "url": "https://www.pixcakeai.com",
+    "title": "像素蛋糕PixCake",
+    "description": "简单易用的AI图像精修工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1534bc40-cb83-40f5-8f09-05cf1fcf77c4.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "1441f8f4-1979-4dbb-9da1-e6b943518249"
+  },
+  {
+    "url": "https://www.aixtsy.com",
+    "title": "咻图AI",
+    "description": "面向影楼的摄影后期AI修图软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/01047cf0-364c-42db-8b89-37f4db2909c3.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "225d0113-8221-4c66-bb58-e554b9c69a90"
+  },
+  {
+    "url": "https://www.restorephotos.io/",
+    "title": "restorePhotos.io",
+    "description": "AI老照片修复",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c10b669-bdc8-4be9-a667-9b6550177ba3.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "64c0efc7-28f3-4958-9b84-3d3295b9a3b5"
+  },
+  {
+    "url": "https://picma.magictiger.ai/zh",
+    "title": "PicMa Studio",
+    "description": "AI一键批量增强、修复、彩色化你的照片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b244c3a9-a778-44f6-8e4f-9f48b390cb6e.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "0f84b41a-f306-4039-83fb-48fa403ce932"
+  },
+  {
+    "url": "https://transpic.cn",
+    "title": "transpic",
+    "description": "AI图像转绘插画创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a1f735c3-0d43-4018-ab98-2ae0040b089f.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "573926c1-e6bf-4b53-96cb-44882d9daaf0"
+  },
+  {
+    "url": "https://www.cutout.pro/zh-CN/photo-colorizer-black-and-white",
+    "title": "Cutout.Pro老照片上色",
+    "description": "Cutout.Pro推出的黑白图片上色",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/647e960f-a7ca-4c57-a7b7-126babcfd480.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "f6183cad-53e9-402c-8497-1d9b27f33787"
+  },
+  {
+    "url": "https://palette.fm/",
+    "title": "Palette",
+    "description": "AI图片调色上色",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b9754579-0481-4597-9dbb-e7614346c3ac.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "1b38a85d-4510-4a3e-bee9-e91e290058c4"
+  },
+  {
+    "url": "https://playgroundai.com/",
+    "title": "Playground AI",
+    "description": "AI图片生成和修图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0eddef75-d42c-4d15-9a30-ecd21c0fe3f4.png",
+    "category": [
+      "图片优化修复"
+    ],
+    "type": "web",
+    "id": "d73580dc-1714-437f-b34a-c969c7aa592c"
+  },
+  {
+    "url": "https://www.ihuiwa.com/workspace/ai-image/partial-redraw?editType=eraser-pen",
+    "title": "绘蛙AI消除",
+    "description": "免费AI修图工具，一键去除图片中多余元素",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ab55966a-c3bb-492f-94d2-9aaa47c4c35e.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "bf9b5613-b8e3-4c6b-a68c-2c00e2838f21"
+  },
+  {
+    "url": "https://www.meijian.com/mj-box/ai-eliminate-intro",
+    "title": "美间AI消除",
+    "description": "AI智能消除工具，轻松消除杂物、水印等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6ca69b24-5c63-4ef8-8391-9125e30e02a8.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "029f8d14-93a4-466a-b549-e20c816bf0a3"
+  },
+  {
+    "url": "https://www.designkit.com/aieraser/?channel=100102",
+    "title": "美图AI消除",
+    "description": "美图设计室推出的AI消除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ac74771e-f158-4777-bede-092de0571f20.jpg",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "a9694778-3b09-4075-b0b6-603e2458a8c0"
+  },
+  {
+    "url": " https://tusiart.com/template/820385276638620489",
+    "title": "吐司AI消除",
+    "description": "吐司AI推出的AI智能消除、去杂物工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/95045c61-31f1-4e7c-9850-e0bd6f5c0a82.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "36109912-58e7-46bc-bafc-1051146bf322"
+  },
+  {
+    "url": "https://www.hama.app/zh",
+    "title": "Hama",
+    "description": "在线抹除图片中不想要的物体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1a192675-0076-4919-8cc2-b3a587238a08.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "ae0e2855-8e09-4c80-a327-a801c6ac69e9"
+  },
+  {
+    "url": "https://www.iopaint.com",
+    "title": "IOPaint",
+    "description": "免费开源的AI图像擦除、修复和处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b893aaa5-70e4-4102-bd00-c19e1e45ab5f.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "2c2ad32a-8e5f-416d-bfe1-7d8c153d91f8"
+  },
+  {
+    "url": "https://bgeraser.com/",
+    "title": "Bg Eraser",
+    "description": "图片物体抹除和清理",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4375c0f8-a69e-4821-9948-284cd08f8c21.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "8a83df36-44f0-4f68-baba-c956497a7a58"
+  },
+  {
+    "url": "https://snapedit.app/",
+    "title": "SnapEdit",
+    "description": "AI移除图片中的任何物体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39862892-b50d-4a24-9542-86d4d00a1b6e.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "29810234-cf2a-4153-a4bb-7242e9bda0e4"
+  },
+  {
+    "url": "https://cleanup.pictures/",
+    "title": "Cleanup.pictures",
+    "description": "智能移除图片中的物体、文本、污迹、人物或任何不想要的东西",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51fc32f8-02d5-4feb-8ccd-e7a039dc27e1.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "28d87638-f0ba-4712-8edd-f4273bbd9250"
+  },
+  {
+    "url": "https://www.cutout.pro/zh-CN/image-retouch-remove-unwanted-objects",
+    "title": "Cutout.Pro Retouch",
+    "description": "Cutout.Pro推出的AI图片物体涂抹去除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d026f4ac-274d-4048-a31b-2112c6c4f60c.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "4768d5a5-ef91-48a5-9b9e-9b5477b64bf7"
+  },
+  {
+    "url": "https://beecut.cn/online-watermark-remover",
+    "title": "蜜蜂剪辑",
+    "description": "AI去水印工具，支持图片和30+流行短视频平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/babc1a96-7b81-4d1a-903d-308b252649f6.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "a22a1800-aabb-4403-9c70-71fadacc2353"
+  },
+  {
+    "url": "https://www.hitpaw.com/remove-watermark.html",
+    "title": "HitPaw Watermark Remover",
+    "description": "AI图片和视频去水印工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82470d54-24fa-4b0d-b1ee-b0266a484417.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "341e9e87-a93b-433d-a747-12f737879312"
+  },
+  {
+    "url": "https://magicstudio.com/zh/magiceraser",
+    "title": "Magic Eraser",
+    "description": "AI移除图片中不想要的物体",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8dc5c36c-3432-4c2b-90e4-7c167a38f554.png",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "00855aef-3c8b-4a27-99e4-8faed791eef8"
+  },
+  {
+    "url": "https://www.watermarkremover.io/zh",
+    "title": "WatermarkRemover",
+    "description": "AI智能删除照片中的水印",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/90244bc9-1645-4d67-bbf9-7da90bd16ad3.jpg",
+    "category": [
+      "图片物体擦除"
+    ],
+    "type": "web",
+    "id": "d5d66bbc-62ac-4964-b763-4b57b8a0d2e7"
+  },
+  {
+    "url": "https://www.meijian.com/e-commerce",
+    "title": "美间AI商拍",
+    "description": "AI电商设计工具，一键生成高质量商品图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f10be9bd-3967-4c5f-9d68-d10b648c4e0f.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "3dc82530-db59-433a-8e57-52f74192eea2"
+  },
+  {
+    "url": "https://www.designkit.com/product-shoot/?channel=100103",
+    "title": "美图商拍",
+    "description": "美图设计室推出的AI商拍工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9f60928e-7239-478e-9645-b9f9c6caafb5.jpg",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "ce3a824f-1b43-4731-b31d-785379241316"
+  },
+  {
+    "url": "https://fengniaoai.com",
+    "title": "蜂鸟AI",
+    "description": "赶海科技推出的跨境电商AI营销工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d6d61aae-ca75-4cd4-9e8b-42b933e8f53c.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "ad20a0c6-cd33-4565-bd55-2195b6326f1e"
+  },
+  {
+    "url": "https://psai.cn",
+    "title": "PhotoStudio AI",
+    "description": "虹软旗下推出的AI商拍工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e93f3940-ebe5-4f6c-9a4b-546563ecddb9.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "9616c7ec-bb27-4201-aa53-12a7c77fc3db"
+  },
+  {
+    "url": "https://www.cliclic.ai",
+    "title": "Cliclic AI",
+    "description": "创客贴推出的AI商品图生成和编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dec91ebf-9739-4f90-893e-e69c6680a4e4.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "982bd9a3-f59d-4327-8000-69a326aad950"
+  },
+  {
+    "url": "https://ai.linkfox.com",
+    "title": "LinkFox AI",
+    "description": "AI电商设计工具，快速生成专业电商图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53796cd7-13c6-4ebc-8fcd-ea59b0e20493.jpg",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "ba5a3569-5ecd-481d-92a8-05e0c0ecce5e"
+  },
+  {
+    "url": "https://chuangziyou.com",
+    "title": "创自由",
+    "description": "快速设计商品图、广告图的AI作图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/584227a6-1783-4316-bd99-7e558ac4ae47.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "367a3ddb-164f-4272-ba31-c994d8765337"
+  },
+  {
+    "url": "https://ling.jd.com/",
+    "title": "羚珑",
+    "description": "京东推出的商品图智能设计小工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/94052e53-2426-4bfe-b1ea-229ea76cbd75.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "7558868a-2c3f-4cb7-a5a4-5b8014dee91a"
+  },
+  {
+    "url": "https://www.redoon.cn",
+    "title": "灵动AI",
+    "description": "专业的AI商品图生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3abcecdf-1db6-4a89-b499-c2e326f3c569.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "7c16b573-4b51-4ef9-a006-aa61a3e9fe13"
+  },
+  {
+    "url": "https://www.photomagic.cn",
+    "title": "PhotoMagic",
+    "description": "AI快速生成商拍图片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebfde73e-08b9-433e-a8fd-7484d206dfe6.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "e47ed423-c29d-4cf7-84f8-6ecad357c93d"
+  },
+  {
+    "url": "https://pebblely.com/",
+    "title": "Pebblely",
+    "description": "AI产品图精美背景添加",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7d894122-6497-42fc-81c9-739e05603983.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "77d3aeb5-0bec-4f07-aa5a-5c6cbce75d2e"
+  },
+  {
+    "url": "https://mokker.ai/",
+    "title": "Mokker AI",
+    "description": "AI产品图添加背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1ba2f356-6c6d-4af0-a1d6-61c3a19d1a4a.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "9585cbf0-c2f8-4e9e-ae6e-a5466cee2d3c"
+  },
+  {
+    "url": "https://www.hsphoto.cn",
+    "title": "花生图像",
+    "description": "AI电商产品图生成和背景抠图工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c4f2f151-8f2d-4090-9474-3b34d13028d2.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "2225b9f4-4578-4f7c-ae83-80b54fff3bc7"
+  },
+  {
+    "url": "https://tushengsheng.com/home",
+    "title": "图生生",
+    "description": "专为电商设计的AI商拍工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c734daf9-eee2-4d75-9843-f7b6476ef5ec.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "8a01acb2-5cde-49c7-9446-cdf4e1552887"
+  },
+  {
+    "url": "https://www.weshop.com",
+    "title": "WeShop唯象",
+    "description": "蘑菇街推出的AI商拍工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2812c4c-8e7a-46ee-bb36-1a8cc92ccd45.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "f4ca0520-9a5d-4632-a13f-2cdb8ab7d02b"
+  },
+  {
+    "url": "https://www.pixgt.cn",
+    "title": "PixGT",
+    "description": "跨境电商AI商拍工具，服装试穿、模特替换、配饰试戴",
+    "image": "https://www.pixgt.cn/images/brand-icon.png",
+    "category": [
+      "商品图生成"
+    ],
+    "type": "web",
+    "id": "6240da2b-ab81-4343-a017-409c8a84e21f"
+  },
+  {
+    "url": "https://www.tripo3d.ai",
+    "title": "Tripo AI",
+    "description": "AI 3D模型生成平台，支持文本、图像一键生成3D模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f7f54356-c530-4a61-800f-2374220e3078.png",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "4bd462e5-326e-4172-9318-7e8cd8e8a5eb"
+  },
+  {
+    "url": "https://3d.hunyuan.tencent.com",
+    "title": "腾讯混元3D",
+    "description": "腾讯推出的一站式3D内容生产AI创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/582fdc9f-fc7b-42e0-9718-cf12e31c7294.png",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "8602750f-cea0-4808-ac96-8871749b9cab"
+  },
+  {
+    "url": "https://hitems.ai",
+    "title": "Hitems",
+    "description": "数美万物推出的AI创意物品生成社区",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e098e5c9-78c7-44db-8b1a-e5087cf79c62.png",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "7cceffe5-477e-4eab-bc11-8e694b2812c0"
+  },
+  {
+    "url": "https://voxcraft.ai",
+    "title": "VoxCraft",
+    "description": "AI生成3D模型的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d63508e-af94-4d59-b290-fd396ca61eb8.png",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "4e3ab9e2-86fc-4fbe-9f4b-edfc8621b49a"
+  },
+  {
+    "url": "https://www.meshy.ai",
+    "title": "Meshy",
+    "description": "AI快速从文本或图像生成3D模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6342ac89-e353-4aa2-a4cb-a21fc07abbba.png",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "ed6c3928-1b8a-4ab1-91f8-8e3fdd63ceae"
+  },
+  {
+    "url": "https://www.luphra.com/",
+    "title": "Luphra",
+    "description": "Prompt-to-matter：文本/草图转可编辑3D并制造实体产品",
+    "image": "https://www.luphra.com/icon.svg",
+    "category": [
+      "3D模型生成"
+    ],
+    "type": "web",
+    "id": "8f2a1b14-2e8e-4603-a8a9-77b4083c022a"
+  },
+  {
+    "url": "https://aibrm.paluai.com/bairimeng",
+    "title": "白日梦",
+    "description": "AI视频创作平台，最长可生成六分钟的视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a2b0dd74-0704-4bee-9d91-5b40719b1410.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "d731df3d-4ad7-47e4-b543-bc630005db73"
+  },
+  {
+    "url": "https://www.ihuiwa.com/workspace/ai-video/custom-action",
+    "title": "绘蛙AI视频",
+    "description": "绘蛙推出的AI图生视频工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d0cff68f-310a-40c1-a980-08ef3d64c4a7.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "7edf01ab-f831-4ca8-af89-6d44ba787a2d"
+  },
+  {
+    "url": "https://typemovie.art",
+    "title": "讯飞绘镜",
+    "description": "科大讯飞推出的AI短视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/705c3ac7-1c42-41fb-9bb1-378198bb6937.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "d6c538a9-72b6-47c2-8940-6ebd289e86b3"
+  },
+  {
+    "url": "https://www.vidu.cn",
+    "title": "Vidu",
+    "description": "生数科技推出的AI视频生成大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0e750f86-c001-4332-93ab-6173e006e469.jpg",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "4da6849e-ffba-4298-b2ee-98d6f2305eac"
+  },
+  {
+    "url": "https://soundviewai.com",
+    "title": "SoundView",
+    "description": "AI视频本地化工具，支持视频配音和翻译",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a48d2d11-18c4-4a5d-80bf-5f257bce1e98.jpg",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "d88b19ae-cefb-4ffa-84a5-e0f75232e750"
+  },
+  {
+    "url": "https://heygen.com",
+    "title": "HeyGen",
+    "description": "AI数字人视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/916064d3-002c-4fef-b744-f49a9125acf7.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "6451147a-4909-428b-b7d6-a1e3ac57a880"
+  },
+  {
+    "url": "https://www.youyan3d.com/platform",
+    "title": "有言",
+    "description": "一站式AI视频创作和3D数字人生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f74145c7-7ec2-44b8-96a6-fb1a8831074b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ec1c23b8-7775-4504-8394-bdaa331c6f0e"
+  },
+  {
+    "url": "https://jurilu.paluai.com",
+    "title": "巨日禄",
+    "description": "一站式AI动漫视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/906b7d02-557b-4c8d-8494-c8413ae52003.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a6d7f824-de34-45e9-9be3-f6dc13c5ab73"
+  },
+  {
+    "url": "http://dis.csqixiang.cn/unpo/jimeng_1.html",
+    "title": "即梦AI",
+    "description": "字节跳动推出的一站式AI创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f8c3efb2-cf24-482a-bac2-da57b84d69a2.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "3957a872-33be-4daa-b4e7-6885b2880337"
+  },
+  {
+    "url": "https://chatglm.cn/video?lang=zh",
+    "title": "智谱清影",
+    "description": "智谱推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0c85ad14-5119-45c6-8e4e-620b733df9bc.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5c44a41f-13cc-4038-910e-72458d39d343"
+  },
+  {
+    "url": "https://video.hunyuan.tencent.com",
+    "title": "腾讯混元AI视频",
+    "description": "腾讯推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2523ea2b-f26c-4894-9e44-0e44206766b4.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "6285e522-3049-474f-8c56-9391a37c2c2b"
+  },
+  {
+    "url": "https://www.kreadoai.com/zh",
+    "title": "KreadoAI",
+    "description": "AI数字人视频营销创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2196fa6-c244-4347-89e5-4b555cf9745c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "46aadc6f-6a55-4f19-9673-cf4399f0786f"
+  },
+  {
+    "url": "https://www.joypix.ai",
+    "title": "JoyPix",
+    "description": "AI数字人创作工具，支持声音克隆",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/104997db-800a-4982-9169-f8c95e0ba05c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5bb0ce54-a83d-419d-bfe5-cd202fbef4d4"
+  },
+  {
+    "url": "https://runwayml.com",
+    "title": "Runway",
+    "description": "AI视频工具，绿幕抠除、视频生成、动态捕捉等功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/adb66c57-c11e-45ae-96b6-d51be9d42543.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "896a8ddb-9b38-42f0-936c-d4371067a91a"
+  },
+  {
+    "url": "https://pika.art/",
+    "title": "Pika",
+    "description": "Pika Labs推出的AI视频生成和编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09746844-4a3a-4560-b46b-74e6a777a195.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "cb90d0a3-fe7c-488d-8e8a-12008d9f25ae"
+  },
+  {
+    "url": "https://imagineclip.com?ref=awesome-ai-tools",
+    "title": "ImagineClip",
+    "description": "AI视频生成工具，支持社交短片、头像视频和风格化场景创作",
+    "image": "https://imagineclip.com/og.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "26be8b11-a41c-4aa3-a962-a8a18faedafa"
+  },
+  {
+    "url": "https://lumalabs.ai/dream-machine",
+    "title": "Dream Machine",
+    "description": "Luma AI推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d96f9599-bb5b-4611-a486-8a52eb965ba2.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "4b3ff24e-0388-45c2-973e-f1371d9205fe"
+  },
+  {
+    "url": "https://tongyi.aliyun.com/wanxiang/wanxvideo",
+    "title": "通义万相AI视频",
+    "description": "通义万相AI视频是阿里推出的...",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/246d4d1b-007e-4f8d-a16c-4175e2ac8f22.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "70871082-efc3-4907-9ad0-d9e1046b0496"
+  },
+  {
+    "url": "https://openai.com/sora",
+    "title": "Sora",
+    "description": "OpenAI推出的AI视频生成模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/46882148-fcea-4e0f-8063-e9416bee502f.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "49cafc8b-ef91-4dbd-9551-986275dbd7f0"
+  },
+  {
+    "url": "https://aigc.yizhentv.com",
+    "title": "秒创",
+    "description": "AIGC内容创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ad35fcc-4063-4374-9a33-2d306d3a22f5.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a9ebe9fa-1ab7-4ca0-8466-5b6ea72c3ca5"
+  },
+  {
+    "url": "https://aic.oceanengine.com/",
+    "title": "即创",
+    "description": "抖音推出的一站式AI智能创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39aaf778-34b2-4a6f-91e6-eb1edb53748d.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "bce3bdff-a6ae-4d3c-901a-d45f28d83706"
+  },
+  {
+    "url": "https://www.hedra.com/",
+    "title": "Hedra",
+    "description": "AI对口型视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a0636f50-861c-40bf-bdd4-3c7bf103dc17.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "6405ba4a-b3e4-4734-8c0f-dd34dfe7e546"
+  },
+  {
+    "url": "https://www.vozo.ai/",
+    "title": "Vozo",
+    "description": "多功能AI视频编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9bb136f5-f2c7-49f8-a2f0-954ef8a12e5f.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "b383eebc-dc7c-47b6-aff8-49055cdf5039"
+  },
+  {
+    "url": "https://viggle.ai/",
+    "title": "Viggle",
+    "description": "AI生成可控的角色动态视频的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/221b0b7a-9945-4f5e-8473-3c64cc9cd1b8.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "1692b905-3a20-48b6-b16c-3f8a304d7004"
+  },
+  {
+    "url": "https://www.tavus.io",
+    "title": "Tavus",
+    "description": "AI数字人克隆和AI视频实时对话工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d2d61b74-684b-4d91-806d-a0ead8dc1fcd.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "cc919a9c-708e-478c-97fd-3c9a9e35f5c4"
+  },
+  {
+    "url": "https://yuewen.cn/videos",
+    "title": "跃问视频",
+    "description": "阶跃星辰推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f88ad8c8-aa13-4c3e-852d-48aaebef2887.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ce3d4e9d-9218-4e3f-a6ff-6655f49f2931"
+  },
+  {
+    "url": "https://yuanjing.zeelin.cn/",
+    "title": "元镜",
+    "description": "AI视频生成工具，支持多模态创意分镜创作服务",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d9cc5f3f-6601-4324-ba0a-409165661a84.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "0f532397-8bff-45e8-9fa3-60edc7bcb06c"
+  },
+  {
+    "url": "https://skyreels.ai/beta",
+    "title": "SkyReels",
+    "description": "昆仑万维推出的AI短剧创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/32d95609-1e64-4266-95d3-8416c6c4d621.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "f36d380b-1db3-4214-a6fd-fe2ab68733f2"
+  },
+  {
+    "url": "https://www.moki.cn/",
+    "title": "MOKI",
+    "description": "美图推出的AI视频短片创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/86c58578-e067-4da0-8b93-a721a7f8a55a.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "08938b9f-2db6-4616-b235-17ad18291ec2"
+  },
+  {
+    "url": "https://shenbi.maoyan.com/",
+    "title": "神笔马良",
+    "description": "猫眼娱乐推出的AI影视创作生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7fcc96a3-829c-4164-bbe2-78041af3e5f2.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "3698a707-ef8e-4d1b-aee6-954bf14607f0"
+  },
+  {
+    "url": "https://video.luchentech.com/zh-CN",
+    "title": "Video Ocean",
+    "description": "潞晨科技推出的多功能AI视频生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d18ef03-269e-4c9c-be7d-66cdd690f12d.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "bb3541a2-e6f6-46bc-aee0-5fccae821299"
+  },
+  {
+    "url": "https://flowgpt.com/flow-studio",
+    "title": "Flow Studio",
+    "description": "FlowGPT推出的AI长视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c7591c8-3c8a-46e1-9ed2-f7c7d89bb3d5.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "afb06fff-4107-4e82-87aa-ee1c8c1ba97d"
+  },
+  {
+    "url": "https://vizard.ai/",
+    "title": "Vizard",
+    "description": "将长视频转为社交短视频的AI工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/95640dfd-57f3-45a8-8047-adb3560c6ea0.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "0602a2ae-a342-4b9e-9368-8a9aae0e91ab"
+  },
+  {
+    "url": "https://xunguang.com/",
+    "title": "寻光",
+    "description": "阿里达摩院推出的全流程AI视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b848b135-e552-44c2-9a3a-64104836a6b5.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "013f3c93-d5f5-4de8-ae25-0d0acf7fb5df"
+  },
+  {
+    "url": "https://hotshot.co/",
+    "title": "Hotshot",
+    "description": "AI视频生成工具，将文本转为3秒逼真视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/32e59109-31fc-4e91-84cd-5b14383c4c37.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "b13f8d3a-1215-43c9-9f11-09ed6867519d"
+  },
+  {
+    "url": "https://vivago.ai/",
+    "title": "Viva",
+    "description": "免费的AI视频生成和图像创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/90a0a86e-dc8c-40e7-9322-7126f75c38e9.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5ebe2879-4bb7-4447-abc5-3950ccf0af76"
+  },
+  {
+    "url": "https://humva.ai",
+    "title": "Humva",
+    "description": "AI数字人生成工具，自定义创建专属数字人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6daa62e-d4d5-418c-bf28-7028eec3e5ea.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "aeeeb2bc-f20a-450f-bec0-ddce5f63f797"
+  },
+  {
+    "url": "https://www.d-id.com/",
+    "title": "D-ID",
+    "description": "AI真人口播视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/da42e3af-8207-4141-a804-b050a461e5bb.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "3b5cbc63-1478-4641-a2bb-e85c43833d6f"
+  },
+  {
+    "url": "https://www.stablevideo.com/",
+    "title": "Stable Video",
+    "description": "Stability AI推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bef706c0-270d-4d91-a4d0-6ebb7902acc5.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c1f0cefd-64d8-415c-b2ab-f0d293c77fd3"
+  },
+  {
+    "url": "https://onestory.art/",
+    "title": "OneStory",
+    "description": "专业的AI故事生成助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d466a9f4-b84f-4d58-9963-cafcdc10f591.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c9d69a04-248e-4e72-af0c-ee4e1931e7de"
+  },
+  {
+    "url": "https://noisee.ai/",
+    "title": "Noisee AI",
+    "description": "月之暗面旗下推出的AI音乐视频MV生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/05f813c3-296c-4558-8ff7-aa90cb66d8a2.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5d0b1c60-8760-4590-942e-68e387eac4be"
+  },
+  {
+    "url": "https://zenvideo.qq.com/",
+    "title": "腾讯智影",
+    "description": "腾讯推出的AI智能创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e28a2263-9ca2-459b-a079-494dfaf2c3fb.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "6480abb8-df7c-4471-8b8f-08553e076fa1"
+  },
+  {
+    "url": "https://virbo.wondershare.cn/",
+    "title": "万兴播爆",
+    "description": "AI数字人口播视频营销工具，海量素材一键套用",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/80ad57ec-da90-4a5e-91aa-051198504ea8.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "29032547-1589-47c6-a51d-6ac84272738d"
+  },
+  {
+    "url": "https://www.sensetime.com/cn/product-detail",
+    "title": "Vimi",
+    "description": "商汤科技推出的可控人物视频生成AI模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c6f6956f-2fd1-4892-8daa-e613008938e7.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "d51fcb8a-0f63-4e4f-99a5-d66731cee157"
+  },
+  {
+    "url": "https://etna.7volcanoes.com/",
+    "title": "Etna",
+    "description": "七火山科技推出的AI文生视频工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a17f32f9-ebb2-419c-8b24-7bd3734cd89f.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "8c1b21a3-e648-4863-8610-ecc1eafcc1b7"
+  },
+  {
+    "url": "https://www.artink.art/",
+    "title": "艺映AI",
+    "description": "AI视频创作工具，支持文生视频、图生视频及视频转漫画功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fa951c74-ee28-4c3b-bbf0-e1303058a344.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c626d8f5-617e-47e9-9894-798b428b1107"
+  },
+  {
+    "url": "https://lensgo.ai/",
+    "title": "LensGo",
+    "description": "AI视频创作工具，支持视频转动漫，替换3D人物",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd1b5175-6ede-4642-aa56-7e30381ea551.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c49f3a52-59af-4310-824e-73477d384ef6"
+  },
+  {
+    "url": "https://member.bilibili.com/york/bilibili-studio/",
+    "title": "必剪Studio",
+    "description": "B站推出的免费AI数字分身定制和视频创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6cf93f95-280a-45ac-80e0-a9b900590c50.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "53177e6c-7385-414a-93c3-b11e2929fbd3"
+  },
+  {
+    "url": "https://aigc.baidu.com",
+    "title": "度加创作工具",
+    "description": "百度官方出品的AIGC创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/56e99072-8b12-4123-a722-31e9aafde6c9.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "09522701-e6f5-4049-b020-3006672613ff"
+  },
+  {
+    "url": "https://wink.meitu.com/",
+    "title": "WinkStudio",
+    "description": "美图推出的桌面端AI视频剪辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f9834f78-4015-4fa3-9388-3be6923c409e.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "b21919ab-00b9-4333-a811-b8bdcbc6bea3"
+  },
+  {
+    "url": "https://www.vmagic.app/zh",
+    "title": "VMagic",
+    "description": "AI视频处理平台，提供视频风格转换、换脸、照片舞蹈等功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/537f456c-8743-439a-b555-8a9bb7697bb2.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ddde04ed-b8d3-49bb-a375-0311a084b40b"
+  },
+  {
+    "url": "https://virtual-man.xfyun.cn/",
+    "title": "讯飞虚拟人",
+    "description": "科大讯飞推出的全栈式AI虚拟人应用服务平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/39f315a1-99b4-4a14-a982-4dfc940718f9.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "62cc7dd2-8fba-4203-bdf6-7f2dea125d40"
+  },
+  {
+    "url": "https://www.flyworks.live/",
+    "title": "飞影数字人",
+    "description": "AI数字人创作平台，支持免费定制数字人",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cbd3881c-d760-4524-bfe9-4c0db162e988.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "12eb6eee-e0b2-49a2-8cac-652abc510b85"
+  },
+  {
+    "url": "https://www.vidustudio.net/zh",
+    "title": "Video Studio",
+    "description": "在线AI视频制作工具，零编辑技能制作专业视频内容",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7040138f-cd36-4f32-92ad-7cd015ac4b5d.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "9517f41e-6650-4050-9abf-eb658423c235"
+  },
+  {
+    "url": "https://app.pixfun.ai/home",
+    "title": "Pixfun",
+    "description": "一站式动画故事AI视频生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/69e28ddc-b8f3-42ec-8670-5cf6906615b8.jpg",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "18351e1e-ac3e-4018-a1d4-dc634f4f104d"
+  },
+  {
+    "url": "https://www.decohere.ai/",
+    "title": "Decohere",
+    "description": "AI视频生成平台，支持音频同步功能",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cf8da4da-9ad2-4f05-bc36-3a8e43656642.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "af83c19d-acb0-4397-969e-fa8397221269"
+  },
+  {
+    "url": "https://avolutionai.com/",
+    "title": "YoYo",
+    "description": "鹿影科技推出的二次元动漫视频AI创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/af295a2e-fd2f-45c9-af06-9f028fbccdaf.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5b4b92fd-a3dc-4125-9d08-ac926d714add"
+  },
+  {
+    "url": "https://www.opus.pro/",
+    "title": "Opus Clip",
+    "description": "AI视频切片工具，自动从长视频中提取精彩片段",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/391b9ce5-6580-47d7-a7a4-48c711e8ec3e.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "7b51a755-90ba-4701-9ea2-cf9f458d5c87"
+  },
+  {
+    "url": "https://filmora.wondershare.com/",
+    "title": "Filmora",
+    "description": "万兴科技推出的AI视频编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2f1c72c7-bf77-45b7-be1d-c238e9811271.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "751a9177-3ef9-4052-8ed9-99b8da349aff"
+  },
+  {
+    "url": "https://www.descript.com/",
+    "title": "Descript",
+    "description": "AI视频编辑工具，支持通过编辑文字来剪辑音视频内容",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8bf3fa60-26af-466e-8de6-43259a8de9b4.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "cc46eb24-0f97-43fc-8cee-54b4da016c63"
+  },
+  {
+    "url": "https://xiling.cloud.baidu.com/",
+    "title": "曦灵",
+    "description": "百度推出的AI数字人和视频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efd58587-4d6d-4b15-abe5-bfd8ef3018e0.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "b9a7f0a2-2c3a-4db5-8663-5677a0d7b37a"
+  },
+  {
+    "url": "https://kaipai.meitu.com/",
+    "title": "开拍",
+    "description": "美图推出的AI口播视频制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/819fc0e1-f35c-4a2b-962a-07e5f489046b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "27817b1f-8205-4cd4-8c4c-f230f1f71c03"
+  },
+  {
+    "url": "https://www.duix.ai/duix-app-landing-page/#/home",
+    "title": "Duix",
+    "description": "硅基智能推出的AI数字人生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e84edb3e-f31a-4a24-929c-5a4fdb363c2e.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "1e1afb0a-bef1-45b6-a24d-990299ea9db8"
+  },
+  {
+    "url": "https://trans.xinpianchang.com/",
+    "title": "场辞",
+    "description": "新片场推出的AI视频字幕制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b4ccb578-3d72-4a93-9cb4-e16661ad6828.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c6aba157-0112-4d0e-8acb-aac684913c4f"
+  },
+  {
+    "url": "https://www.yiqijian.com/",
+    "title": "一起剪",
+    "description": "AI短视频创作平台，图文一键成片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9c7463bf-a485-43c4-88d8-55682a1c5fdb.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "e71cee27-317e-43fb-9723-bfa4ac07d50c"
+  },
+  {
+    "url": "https://spikes.studio",
+    "title": "Spikes Studio",
+    "description": "AI自动将长视频切片剪辑为短视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/82b0d0b2-0dca-45f6-8e11-cd948dcc0961.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "d3779046-44c3-4d82-9665-f8829ad41785"
+  },
+  {
+    "url": "https://workspace.google.com/products/vids/",
+    "title": "Google Vids",
+    "description": "谷歌推出的AI视频创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aa5df58b-0e11-4482-b34c-df5bc0ce99c1.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "f02c6452-52a4-485d-9156-de8364af777d"
+  },
+  {
+    "url": "https://domoai.app/",
+    "title": "DomoAI",
+    "description": "一键将照片和视频动漫化的AI工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3f20c8c-f954-4dc4-8462-704e32ac75cc.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5c5a75d2-b4cf-4ece-9cac-874aa3a3fa9c"
+  },
+  {
+    "url": "https://gatekeep.ai/",
+    "title": "Gatekeep",
+    "description": "AI教学视频生成工具，可生成数学物理问题解释视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2050ac0b-7220-41fc-9d31-c9fc2e1b4b98.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "2e1a378f-96c8-4dac-a164-f02d5c01280f"
+  },
+  {
+    "url": "https://www.morphstudio.com/",
+    "title": "Morph Studio",
+    "description": "高质量的AI文本到视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b5353c63-bf87-468f-b118-f451ee83e64e.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "4d5101d6-965d-4093-bbf6-3bbc0807fcbd"
+  },
+  {
+    "url": "https://haiper.ai/",
+    "title": "Haiper",
+    "description": "AI视频生成和重绘工具，支持文本/图像转视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2adf9fba-7531-4d43-a73f-eb0f0f4bad38.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "7c51ea02-215b-4a39-be15-1423f81372a1"
+  },
+  {
+    "url": "https://www.showrunner.xyz/",
+    "title": "Showrunner",
+    "description": "AI动画视频剧集生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b13ea54-52b3-403d-b39c-0348692cb38c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "78b1088f-efda-44d0-9fc1-1f73585c1957"
+  },
+  {
+    "url": "https://aigc.zego.im/#/MyHome",
+    "title": "即构数智人",
+    "description": "即构科技推出的AI数字人创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7483e42b-718e-4edc-9651-d3a9d226678c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "cf70d524-623e-4495-b1b0-919bac7efdee"
+  },
+  {
+    "url": "https://www.kuaijianji.com/",
+    "title": "快剪辑",
+    "description": "360旗下的AI视频剪辑工具，AI成片、AI数字人、智能添加字幕、去水印等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/939761b8-2040-49f7-b3b1-a389fc5fb777.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "4c34613c-522f-4bae-949a-4acb11b4a1d9"
+  },
+  {
+    "url": "https://www.chanjing.cc/",
+    "title": "蝉镜",
+    "description": "AI数字人视频生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/33030e95-b250-448d-9684-ac077245b3ba.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "55fb9e89-8ee5-480d-af94-bf3877271f91"
+  },
+  {
+    "url": "https://shanjian.tv/",
+    "title": "闪剪",
+    "description": "AI数字人短视频创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8be5a21d-ab4d-46cd-a62e-06d988d5d992.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "3e9e48e5-b879-4caf-9cd9-f37000f78565"
+  },
+  {
+    "url": "https://wonderdynamics.com/",
+    "title": "Wonder Studio",
+    "description": "AI自动为CG角色制作动画、打光并将其合成到真人场景中",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/840849e5-f563-481f-a505-9593d48b4ad0.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "c5a55b6e-f99c-41dd-9ddb-7448432659e0"
+  },
+  {
+    "url": "https://magicam.ai/",
+    "title": "Magicam",
+    "description": "实时的AI直播/视频换脸工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7afb69c1-e7c8-4841-a180-9913d59480c5.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "022f41dd-05db-40fa-baef-d57af22d9000"
+  },
+  {
+    "url": "https://livefaceswap.ai/zh",
+    "title": "LiveFaceSwap AI换脸",
+    "description": "提供网页体验和Windows客户端的实时AI换脸工具，支持变装、风格重绘与虚拟摄像头输出",
+    "image": "https://livefaceswap.ai/images/og/livefaceswap-ai.jpg",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "64c4f5a2-d9e5-4abd-8c0d-116d146042ba"
+  },
+  {
+    "url": "https://ltx.studio/",
+    "title": "LTX Studio",
+    "description": "AI电影制作和视频短片生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3c844fd-e1f6-493c-81f6-c88ca3d2efc8.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a3cf8378-3dd6-423a-b4bc-9401c1c08ef8"
+  },
+  {
+    "url": "https://www.clipfly.ai/",
+    "title": "Clipfly",
+    "description": "一站式AI长视频制作和编辑平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/33567e5a-3527-408b-9994-e7f26f5aec35.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "17f4ce61-815c-4b57-ac9e-a0d72741ac06"
+  },
+  {
+    "url": "https://www.captions.ai/",
+    "title": "Captions",
+    "description": "AI驱动的视频剪辑和制作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/14519c6b-6e17-4f6c-874d-5f68495a519e.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "027a9af9-2b98-46fb-bf5d-4546b4e8619c"
+  },
+  {
+    "url": "https://capsule.video/",
+    "title": "Capsule",
+    "description": "AI驱动的在线视频剪辑工具，个人和小团队免费",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/17379d49-d948-47bf-956e-dc31905c8346.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "7f76e945-8d6d-44c1-b5d5-09bfb2e0cf3c"
+  },
+  {
+    "url": "https://www.goenhance.ai/",
+    "title": "GoEnhance",
+    "description": "AI视频风格转换和画质增强工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9e354dcf-d221-4880-88dc-84c16e117438.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "9e358955-423e-4f09-bc2d-c99c4fed437b"
+  },
+  {
+    "url": "https://invideo.io/",
+    "title": "InVideo AI",
+    "description": "人工智能视频创作和剪辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d7e89b33-f251-4b9a-8027-813ba218b05b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "e92dee74-764b-4366-afe0-ae65c6dc1f4c"
+  },
+  {
+    "url": "https://www.unscreen.com/",
+    "title": "Unscreen",
+    "description": "AI智能视频背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a59aacdd-65f0-462b-bf96-9cf29a5eec7b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a5e00b04-ec81-4dca-821d-9f7f9ececb1f"
+  },
+  {
+    "url": "https://seele.tv/",
+    "title": "SEELE TV",
+    "description": "浏览器端AI视频创作工作室",
+    "image": "https://seele.tv/favicon.ico",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "de018197-1657-49c8-a93e-287b3b2a8dfe"
+  },
+  {
+    "url": "https://ebsynth.com/",
+    "title": "EbSynth",
+    "description": "AI将真人视频转化为油画风动画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/24c645a6-b823-445c-9db6-f827b86bdcfc.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "10b464bd-46ce-4fc4-97bf-fa54e9e0186e"
+  },
+  {
+    "url": "https://app.artflow.ai/",
+    "title": "Artflow",
+    "description": "AI创建生成视频动画",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d15baff3-0cd4-4b55-83c6-5a23e1259db3.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "9916d948-d6b3-48e9-b6fa-fd20ca6ab7cf"
+  },
+  {
+    "url": "https://www.kaiber.ai/superstudio/",
+    "title": "Kaiber",
+    "description": "图片文字转视频的AI引擎",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f6c94859-98df-4508-ae2b-dd7a99d0a8da.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "065b0cf3-88dd-4a8f-9770-d949548565c6"
+  },
+  {
+    "url": "https://www.typeframes.com/",
+    "title": "Typeframes",
+    "description": "AI快速生成高质量的产品介绍视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/df4d2132-5926-4575-968e-76be4dce3b06.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "74e1d4c9-56e0-4dd0-8fc3-03bdc66302ae"
+  },
+  {
+    "url": "https://dreamfaceapp.com/",
+    "title": "DreamFace",
+    "description": "让图片动起来的AI工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83676b12-273e-48aa-a10a-4f3da662fa60.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "0cff29b8-5c8c-44dd-8384-cd5a3a11c57b"
+  },
+  {
+    "url": "https://mootion.com/",
+    "title": "Mootion",
+    "description": "AI原生3D动画创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5481b98f-c48d-4c3f-94d2-8cb6c025be00.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "db9968aa-2779-45d9-b37c-c7be5953d055"
+  },
+  {
+    "url": "https://app.pixverse.ai/",
+    "title": "PixVerse",
+    "description": "爱诗科技推出的AI视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/facde8b6-d54a-41a2-8761-b891690d6e78.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ec73e8d1-fa5c-4bfe-86af-8219e34dff6b"
+  },
+  {
+    "url": "https://www.laihua.com/",
+    "title": "来画",
+    "description": "动画和数字人智能生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9eba0f91-4058-464c-a3c6-4f8296637dba.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "2be9eb5d-a625-4fc7-90d0-0e315eef6ed1"
+  },
+  {
+    "url": "https://weta365.com/conduct",
+    "title": "奇妙元",
+    "description": "AI数字人视频生成平台，由出门问问推出",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53db2e52-eba1-4b8e-b625-3d2139d4c56c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "9d839988-607f-40ad-8fdc-3cc9f57a4755"
+  },
+  {
+    "url": "https://huiyingzimu.com/",
+    "title": "绘影字幕",
+    "description": "一键智能在线自动为视频加字幕",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8b959c84-4fad-4f74-bff0-e0d4bffce172.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "8fa4aa2a-cbe6-446d-b03b-1f132b67e6f7"
+  },
+  {
+    "url": "https://fliki.ai/",
+    "title": "Fliki",
+    "description": "AI文字转视频并配音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d5706d48-61c7-46f1-a31f-7550a1e41204.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "2b9f9168-277d-4d17-8752-da00e266e7a7"
+  },
+  {
+    "url": "https://anylang.ai/",
+    "title": "Anylang.ai",
+    "description": "AI视频翻译并保持音色和口型的同步",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7b42178e-29db-4646-a222-49c1faa4c7a7.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "75582388-5a0d-4d24-a7f8-c7c2973dc1db"
+  },
+  {
+    "url": "https://www.aistudios.com/",
+    "title": "DeepBrain",
+    "description": "AI口播视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/018720a0-f5e0-46cd-9a36-76e62587e421.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "02d4f753-81cd-4101-b15e-766dd3c753b6"
+  },
+  {
+    "url": "https://www.synthesia.io/",
+    "title": "Synthesia",
+    "description": "AI视频生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c3d0b579-4e07-427a-8fa8-73a44f66a24c.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "1d1b9679-6b90-429e-b407-d89fc9e50d88"
+  },
+  {
+    "url": "https://lumen5.com/",
+    "title": "Lumen5",
+    "description": "AI将博客文章转换成视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/48ad79f7-d5a2-4088-b712-0ec57ca5b546.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "48a9bc7b-7fc7-4143-b0f9-d314fa6d8b81"
+  },
+  {
+    "url": "https://ahrefs.com/writing-tools/paraphrasing-tool",
+    "title": "Rephrase.ai",
+    "description": "AI文字到视频生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/dd755332-6c44-4491-93fb-0b40fe53e4b0.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a56ef018-991c-402b-8625-a17ad5aa66c3"
+  },
+  {
+    "url": "https://www.animiz.cn/microvideo/",
+    "title": "万彩微影",
+    "description": "AI智能自动生成动画短视频",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/55cc45c2-8727-43ab-9e8c-df277b2bce7a.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5734aced-e8e7-4e36-af33-d3619ca34687"
+  },
+  {
+    "url": "https://reccloud.cn/",
+    "title": "录咖",
+    "description": "一站式AI音视频总结和转录处理工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f4f5db62-3371-45f5-9769-baf5bc33dcfc.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "86ed39c6-da7f-4f5a-8e8b-ebc15b1d6329"
+  },
+  {
+    "url": "https://www.guaishouai.com/",
+    "title": "怪兽AI数字人",
+    "description": "人工智能数字人短视频创作和直播平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/091e1996-ef8f-4c16-b3a3-fe2b3f8f1268.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ac7c7973-407c-4061-bf0a-3a24449866ba"
+  },
+  {
+    "url": "https://teamcut.shanjian.tv/",
+    "title": "团队快剪",
+    "description": "闪剪智能专为团队带货打造的AI视频工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b4b3396-a219-4d99-b18d-b3947acdec27.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "613af843-4bfd-4384-9b6f-3d382e47e063"
+  },
+  {
+    "url": "https://cn.jollytoday.com/",
+    "title": "鬼手剪辑GhostCut",
+    "description": "多功能AI视频二创剪辑和翻译工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1edfde75-a1ab-4492-8360-032dd9d46e08.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "32e57c81-c843-4ffa-9a47-d030685988ee"
+  },
+  {
+    "url": "https://www.mooliv.com/",
+    "title": "模力视频",
+    "description": "AI驱动的视频编辑平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0d420cd9-4222-4573-b6fd-24d3e5a162ba.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "ccf08ceb-ddf2-4ba7-8f35-f62405d0c33a"
+  },
+  {
+    "url": "https://gencraft.com/",
+    "title": "Gencraft",
+    "description": "AI艺术画视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/3c29830a-531f-4573-a293-741ee374d245.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "8c5892c1-a1e4-403c-b4b9-eb2714defe1f"
+  },
+  {
+    "url": "https://synthesys.io/",
+    "title": "Synthesys",
+    "description": "AI虚拟人出镜讲解",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f2c20a2-6e10-4f9f-b1a3-17b827652d0b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "1e78ad27-ae45-447e-8e2f-dbaef8830d49"
+  },
+  {
+    "url": "https://www.veed.io/zh-CN/tools/video-background-remover",
+    "title": "Veed Video Background Remover",
+    "description": "Veed推出的AI视频背景移除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/51d24356-e7a5-4b22-98cd-245cfbb4ac35.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "a7f2aa59-ce18-40e6-9e3d-6c6fafef7ee0"
+  },
+  {
+    "url": "https://hourone.ai/hour-one-2-0/",
+    "title": "Hour One",
+    "description": "人工智能文字到视频生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1922fa18-1db0-4978-b241-43da07f2d539.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "e5bbe16d-9641-4b74-b8fc-3c033fe30b46"
+  },
+  {
+    "url": "https://bgrem.deelvin.com/zh/remove_video_bg/?params=start",
+    "title": "BgRem",
+    "description": "无水印AI视频背景移除",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/6efad195-58aa-41c1-a79f-9bf36bfe20fe.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "4402660f-0477-48f9-9b14-2a498c463823"
+  },
+  {
+    "url": "https://colourlab.ai/",
+    "title": "Colourlab.ai",
+    "description": "好莱坞也在用的AI视频颜色分级工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1a59810-ca93-454e-aad0-d347797da098.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "edb42a3e-6741-4c3f-b11d-556a285c9526"
+  },
+  {
+    "url": "https://www.colossyan.com/",
+    "title": "Colossyan",
+    "description": "AI虚拟人出镜视频生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b781ba3f-87ff-41e9-b87e-ce831e7776dc.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "874bcf60-26be-4dee-88d5-e3bfe097bb5a"
+  },
+  {
+    "url": "https://app.avclabs.com/#/",
+    "title": "AVCLabs",
+    "description": "AI自动移除视频背景",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/63b6b541-6f99-408c-aa48-c7fb929d8d4f.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "88a26caa-95c6-4847-8dc8-dc6879f2ccb1"
+  },
+  {
+    "url": "https://elai.io/features/",
+    "title": "Elai.io",
+    "description": "AI文本到视频生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/aefc33ac-22d0-47b9-9839-d897e5cae1b1.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "5b2c2af8-6f7b-4955-9c77-938b1724511c"
+  },
+  {
+    "url": "https://pictory.ai/",
+    "title": "Pictory",
+    "description": "AI视频制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/87e50df2-927f-46a8-877a-03bf2f71866b.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "cf573b16-64b2-4a65-b5a6-96f8b664d44c"
+  },
+  {
+    "url": "https://www.steve.ai/",
+    "title": "SteveAI",
+    "description": "Animaker旗下AI在线视频制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1782767a-02ab-43dd-907c-8fa2dfae82c6.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "711603a4-84f2-49f1-af4a-84b21883521f"
+  },
+  {
+    "url": "https://www.rask.ai/",
+    "title": "Rask",
+    "description": "AI视频本地化解决方案，支持超过130种语言",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c18e0d8-d9ab-4303-a84f-b593b4a71dfe.png",
+    "category": [
+      "视频工具"
+    ],
+    "type": "web",
+    "id": "3e9302b6-510a-4838-b708-befacd16f4f6"
+  },
+  {
+    "url": "https://www.moyin.com",
+    "title": "魔音工坊",
+    "description": "AI配音工具，轻松配出媲美真人的声音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b7dd4497-8b73-468f-9795-b7668cd02ccf.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "1a7c0178-691e-4d61-a7aa-58ad716fe627"
+  },
+  {
+    "url": "https://peiyin.xunfei.cn/?ftype=14",
+    "title": "讯飞智作",
+    "description": "科大讯飞推出的AI转语音和配音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/99ab9d75-94c4-4b96-a30c-d27375d0cde1.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "29498b79-b229-46a7-b9e6-f1599a7236ab"
+  },
+  {
+    "url": "https://www.suno.ai",
+    "title": "Suno",
+    "description": "高质量的AI音乐创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/0123c417-d9a0-43a8-a3de-720376dbb799.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9d40ec28-d4a9-45a4-8359-b49dd31dc77f"
+  },
+  {
+    "url": "https://www.haimian.com",
+    "title": "海绵音乐",
+    "description": "字节跳动推出的免费AI音乐创作和发现平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2ceb60a-63f3-4324-a8b5-6f0d72c3170e.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "24118b2e-491c-4eff-b81c-10059f0a7b34"
+  },
+  {
+    "url": "https://www.yinfeng.cn/home",
+    "title": "音疯",
+    "description": "昆仑万维推出的AI音乐创作平台，一键生成原创歌曲",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/48bd6b42-76cf-4403-a47f-a73d6f010e08.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9571c95c-9e8b-47ef-ab68-6e8c533b86f7"
+  },
+  {
+    "url": "https://lang123.top",
+    "title": "琅琅配音",
+    "description": "智能文本转语音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d1facd3d-eb97-407c-b4c2-2874ed46987d.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "f4d02c0c-b16c-40f2-81cc-8bcaf3aa4fcc"
+  },
+  {
+    "url": "https://noiz.ai/landing",
+    "title": "Noiz AI",
+    "description": "AI配音工具，支持文本转语音和声音克隆",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2d1ce12c-479f-4ba1-8e7a-fcd22d02a447.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "275be77b-d13c-4ede-a474-714006c1ea51"
+  },
+  {
+    "url": "https://www.minimax.io/audio",
+    "title": "MiniMax Audio",
+    "description": "MiniMax推出的AI语音合成工具，支持声音克隆",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/406e214c-3113-4d52-b84e-3a77ca5cc052.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "1bf607f7-22e4-46ad-b9fc-f86641054457"
+  },
+  {
+    "url": "https://www.mureka.ai",
+    "title": "Mureka",
+    "description": "昆仑万维推出的 AI 音乐商用创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1bd634ef-0b45-4674-bbdb-8f0b5cfad4ac.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "3e59098d-db9c-4adb-ae30-bbb12c14a091"
+  },
+  {
+    "url": "https://www.tianpuyue.cn",
+    "title": "天谱乐",
+    "description": "唱鸭团队推出的首个多模态音乐生成大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7c0002f0-1fe4-4e91-8bf5-57c3c46f274e.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "31deb4c8-8ede-41e3-a2cd-87f49614b57f"
+  },
+  {
+    "url": "https://audioeditor.ximalaya.com",
+    "title": "音剪",
+    "description": "喜马拉雅推出的一站式AI音频创作平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ebff3c5e-bd34-47ff-b997-f670b7c58047.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "27841cde-efd9-4d83-a3c3-db9e55d3a9d2"
+  },
+  {
+    "url": "https://www.iflyrec.com/zhuanwenzi.html",
+    "title": "讯飞听见",
+    "description": "科大讯飞推出的在线AI语音转文字工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c00d2d6d-de68-4638-8270-369a50f83f2d.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "2578233e-3c68-436b-9cb7-5bde4f9669cc"
+  },
+  {
+    "url": "https://memo.ac",
+    "title": "MemoAI",
+    "description": "免费的AI语音转文字工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e2abe711-3704-4634-890b-ad577a77dd18.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "d483c612-0568-43cd-b236-1367b224ae71"
+  },
+  {
+    "url": "https://www.reecho.ai",
+    "title": "Reecho睿声",
+    "description": "超拟真的中英文AI语音克隆/生成平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a9b6769-7929-4394-833e-2e797d77ab14.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "215a1296-ca84-439c-a001-dda131f790cb"
+  },
+  {
+    "url": "https://www.udio.com",
+    "title": "Udio",
+    "description": "免费的AI音乐创作工具，每月可生成1200首歌曲",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bc353220-8004-4cc3-b8bb-59200c5c43ad.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "616f9a72-ca30-4daf-9e99-b9308fa4e2c7"
+  },
+  {
+    "url": "https://tianyin.163.com/",
+    "title": "网易天音",
+    "description": "网易推出的一站式AI音乐创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/363171b6-ab43-4079-93a3-0a2a265adfa5.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "974b5533-ae67-485c-a3aa-28dfcfeb7dd7"
+  },
+  {
+    "url": "https://y.qq.com/tme_studio/index.html#/",
+    "title": "TME Studio",
+    "description": "腾讯音乐推出的智能音乐创作助手",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/197da5c5-9e14-4dc3-b92a-70b175a16d66.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "1c6d23c4-3ae4-44b2-a64b-37b1c90782b4"
+  },
+  {
+    "url": "https://lyricsintosong.ai/zh",
+    "title": "Lyrics Into Song AI",
+    "description": "在线AI音乐创作工具，输入歌词创建个性化歌曲",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8a8d7c19-e659-406c-b5ec-936130c64ff9.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "fb05cf23-8550-4984-b7c3-bbe8c19ab5fe"
+  },
+  {
+    "url": "https://www.stableaudio.com",
+    "title": "Stable Audio",
+    "description": "Stability AI最新推出的音乐生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5de5214c-453c-47e2-a1b0-293312d412fb.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "bc09fd31-d350-47f4-b17b-20b10fa8d68c"
+  },
+  {
+    "url": "https://texttospeech.im/zh-CN",
+    "title": "TextToSpeech",
+    "description": "完全免费的AI文字转语音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/09347be4-f600-47f1-a655-78888327a3ac.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "13f1a26e-dda8-42af-be61-faae28cca532"
+  },
+  {
+    "url": "https://ttsmaker.cn",
+    "title": "TTSMaker",
+    "description": "马克配音（MakVoice）推出的免费AI文字转语音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b7105f23-01de-4df9-a4b3-4664db0519e6.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "6865fd5e-fed6-4fd2-9056-03b0771484f9"
+  },
+  {
+    "url": "https://lovo.ai",
+    "title": "LOVO AI",
+    "description": "AI人声和文本转语音生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a3a18677-8535-4dc9-ba2a-2276be632973.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "3de1b8fd-a0bc-457b-a8ba-9de16fc1c2b2"
+  },
+  {
+    "url": "https://uberduck.ai",
+    "title": "Uberduck",
+    "description": "开源的AI语音生成社区，5000多种不同的声音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/bd2d656a-dead-4bb9-9f25-f0751e874b36.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "20005394-1389-43fa-bd46-73a3b49b5963"
+  },
+  {
+    "url": "https://try.elevenlabs.io",
+    "title": "ElevenLabs",
+    "description": "AI文本转语音，支持包含中文在内的28种语言",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a07b0002-ab77-4b1c-8e04-223d943fb28b.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9018ab4b-1bac-4221-b3d1-8da6b832ba94"
+  },
+  {
+    "url": "https://sonauto.ai",
+    "title": "Sonauto",
+    "description": "免费的AI音乐生成和歌曲创作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/507e54cd-8860-4162-b173-5875663da22c.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "bc634edf-30b7-43a6-9c73-e32d3399358f"
+  },
+  {
+    "url": "https://www.tiangong.cn/music",
+    "title": "天工SkyMusic",
+    "description": "昆仑万维发布的国内首个AI音乐生成大模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e25f72a4-85d1-4778-b1f0-ce142a90a49c.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "285b41de-c794-4230-a5ef-74a7184ecc2d"
+  },
+  {
+    "url": "https://dubbing.tech",
+    "title": "大饼AI变声",
+    "description": "免费专业的AI变声软件，一键实时语音变声",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/38ec0d9e-70b2-40e4-927d-aa61047e00d9.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "dd3231a8-3913-4285-b996-f09a2aa9fffb"
+  },
+  {
+    "url": "https://product.supertone.ai/shift",
+    "title": "Supertone Shift",
+    "description": "AI驱动的实时语音变换软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5af526ae-147d-40cc-b925-35a2a110ffc2.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9637648e-d6f7-4100-bade-44ed15581297"
+  },
+  {
+    "url": "https://www.riffusion.com/",
+    "title": "Riffusion",
+    "description": "AI生成不同风格的音乐，免费开源",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f50da0e1-4cf3-4411-b036-9d60a357c670.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "fb700747-7942-48bb-bd46-72e7c0aff3fc"
+  },
+  {
+    "url": "https://podcast.adobe.com/",
+    "title": "Adobe Podcast",
+    "description": "Adobe推出的在线AI音频录制和编辑工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/96bfb314-9f7b-48cb-b235-8b59605bcbba.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "c9b285b3-9708-4497-ba6b-158349a866ef"
+  },
+  {
+    "url": "https://xstudio.music.163.com",
+    "title": "网易云音乐·X Studio",
+    "description": "网易云音乐与小冰智能联合推出的免费AI歌手音乐创作软件",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b15804fc-ee13-4fc2-a6c2-cb41a5a1ef41.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9c2912a8-f0df-4217-8ea8-0b5b71911c61"
+  },
+  {
+    "url": "https://www.icnpy.com",
+    "title": "刺鸟配音",
+    "description": "刺鸟科技推出的专业AI配音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5a988f63-e2fa-4646-bff9-bddeed0305b7.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "fb3be465-8b23-49a7-8e8e-890a99b5fe3b"
+  },
+  {
+    "url": "https://www.wondercraft.ai",
+    "title": "Wondercraft",
+    "description": "AI音频内容生成工具，可创建播客有声书等",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4d1304f9-93ca-4d97-8d5c-b213245b9e68.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "82ab6384-7977-4d72-b3dd-cf123f506977"
+  },
+  {
+    "url": "https://fryderyk.ai",
+    "title": "Fryderyk",
+    "description": "AI音乐创作工具，集成了多种乐器声音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83913f6d-d9a3-4b5e-a7e0-606f25aa9bc0.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "22904a71-8cc9-4fec-a399-a87b03ae91bf"
+  },
+  {
+    "url": "https://voicenotes.com",
+    "title": "Voicenotes",
+    "description": "AI驱动的语音笔记工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e89a65ff-7910-4a12-9212-ae08c53449b2.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "3d4546c4-6fcb-472f-8f1e-5f3e554819d1"
+  },
+  {
+    "url": "https://www.optimizerai.xyz",
+    "title": "OptimizerAI",
+    "description": "AI声音效果生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5b3248f8-0c7c-43e5-b828-5aa3ef097539.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "32fc10d4-0995-4d48-9fc1-02f6cb1c972e"
+  },
+  {
+    "url": "https://ace-studio.timedomain.cn",
+    "title": "ACE Studio",
+    "description": "AI歌声合成工具，输入歌词与旋律即可生成宛如真人的歌声",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/956f0b48-609d-43ef-aa7d-8431fe581188.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "da15e888-247e-46f8-b0ee-47a9156b1acb"
+  },
+  {
+    "url": "https://aigc.unisound.com",
+    "title": "蓝藻AI",
+    "description": "云知声旗下的AI配音和声音克隆平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1c7d77ac-a2a7-40e7-81a6-75a677244aed.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "000eccaf-6229-495d-b02c-b735ef27b279"
+  },
+  {
+    "url": "https://deepgram.partnerlinks.io",
+    "title": "Deepgram",
+    "description": "快速低成本的AI语音文本互转API平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/483c4018-6fb7-4921-a4f6-d2877875f700.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "f0c07120-d26b-4394-9855-be6046c9179d"
+  },
+  {
+    "url": "https://audiobox.metademolab.com",
+    "title": "Audiobox",
+    "description": "Meta推出的免费开源的AI语音和声音生成模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e2cb9ff8-b8b1-4ac3-8299-a513612b7d4b.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "cc757637-c8ee-4c74-b00f-4f700cd2f801"
+  },
+  {
+    "url": "https://www.resemble.ai/",
+    "title": "RESEMBLE.AI",
+    "description": "AI人声生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1d7159ae-d016-4479-ae66-a9f5ece65e2b.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "b8a1bd6f-0e7a-4b58-aa67-7b4740f49b88"
+  },
+  {
+    "url": "https://www.ibm.com/cloud/watson-text-to-speech",
+    "title": "IBM Watson文字转语音",
+    "description": "IBM Watson文字转语音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/121eb807-8281-4c65-9ee8-67099c84b799.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "244b3e8b-b402-461b-809b-4032dcce619d"
+  },
+  {
+    "url": "https://fakeyou.com/",
+    "title": "FakeYou",
+    "description": "Deep Fake文本转语音",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2bbe5bd9-db06-42f3-ad7d-14feebb1c7bf.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "a549f7aa-b011-4440-8f27-c36c4181859a"
+  },
+  {
+    "url": "https://bgmcat.com/home",
+    "title": "BGM猫",
+    "description": "灵动音科技推出的AI智能生成BGM音乐",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b2a11138-fc71-4b9e-ace0-48af2ad779bd.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "db9e07fa-ffe3-46ea-b106-3f1982bd999a"
+  },
+  {
+    "url": "https://www.kzzimu.com",
+    "title": "快转字幕",
+    "description": "AI语音视频转文字和字幕的工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2a7a9d28-a5ad-4d7f-b496-f507825de6e9.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "948cb506-a994-4dd9-af0e-1c7fb9acb516"
+  },
+  {
+    "url": "https://yueyin.zhipianbang.com",
+    "title": "悦音配音",
+    "description": "AI智能在线配音语音合成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9510f56f-a84c-4c2b-a3a8-bd6256117612.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "9359e0bf-124c-470a-a191-4f98df048e67"
+  },
+  {
+    "url": "https://www.soundbug.com",
+    "title": "音虫",
+    "description": "内置AI音乐编曲的音乐制作工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c03602d5-6815-4963-ae73-5d735a5d8185.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "59a65575-6724-48e8-8ca8-fc653245a988"
+  },
+  {
+    "url": "https://mubert.com/",
+    "title": "Mubert",
+    "description": "AI BGM背景音乐生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a680304e-ea78-4247-b2d0-0f4e3c15f1b4.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "0f24243d-2cd5-4d61-b6c9-75f340d69c18"
+  },
+  {
+    "url": "https://www.beatoven.ai/",
+    "title": "beatoven.ai",
+    "description": "免版税AI音乐创建平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d29c0eb1-33d8-47c0-a268-79e232eaec81.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "c3379006-3df9-4e4e-9e01-7d6b84782570"
+  },
+  {
+    "url": "https://beatbot.fm",
+    "title": "BeatBot",
+    "description": "输入文本提示快速生成歌曲和音乐",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a348ec19-bc5e-47bb-8daf-48aaed9f4f5a.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "98625846-fa19-47fe-9a12-aa12fd750e34"
+  },
+  {
+    "url": "https://audo.ai/",
+    "title": "Audo Studio",
+    "description": "AI音频清洗工具（噪音消除、声音平衡、音量调节）",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/351f27f0-65cb-439d-9f25-f7a2a575ea76.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "372be2da-4d58-4c40-b88d-16822a63465b"
+  },
+  {
+    "url": "https://www.naturalreaders.com/",
+    "title": "NaturalReader",
+    "description": "AI文本转语音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7067dad5-0733-45f4-b9b0-6e7afdd15a84.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "28ba6b5b-f3d4-4761-aa1b-fffd99466f24"
+  },
+  {
+    "url": "https://www.assemblyai.com/",
+    "title": "AssemblyAI",
+    "description": "转录和理解语音的AI模型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/efc44f7b-7b31-46dd-9525-c867b5992b84.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "35842524-b563-4c77-84b4-729a97d712ed"
+  },
+  {
+    "url": "https://www.lalal.ai/",
+    "title": "LALAL.AI",
+    "description": "AI人声乐器分离和提取",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/70fa1136-f5ef-4b36-b807-2296d77328d7.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "7b4507f0-20f9-485c-a59e-4fed6c14c5e1"
+  },
+  {
+    "url": "https://krisp.ai/",
+    "title": "Krisp",
+    "description": "AI噪音消除工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1492b2a1-a012-4d53-869a-6b26e5fd87c1.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "69cbd751-f7ad-4841-b8a3-22a62436d49a"
+  },
+  {
+    "url": "https://play.ht/",
+    "title": "Play.ht",
+    "description": "超真实在线AI语音生成",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e8ed80d0-794d-4126-b734-edf936fe0eec.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "29da4ed0-abd4-4b04-bcc4-5b77c4605e88"
+  },
+  {
+    "url": "https://murf.ai/",
+    "title": "Murf AI",
+    "description": "AI文本转语音生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ecf2fa4b-fbe9-405b-b6d6-3caee36ec20a.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "a4304e44-b2af-435e-b24c-7a8de3307f0e"
+  },
+  {
+    "url": "https://www.lemonaide.ai",
+    "title": "Lemonaid",
+    "description": "AI音乐生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5c8d1783-0d9d-4c06-8ed4-7e15c47eef10.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "756a889c-66c6-42d8-b630-e621d77a0e3e"
+  },
+  {
+    "url": "https://soundraw.io/",
+    "title": "Soundraw",
+    "description": "AI音乐生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4b05daaf-e998-448f-bcaf-568b6d43d787.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "06a7c6f5-04bd-49da-922c-53342686b39f"
+  },
+  {
+    "url": "https://boomy.com/",
+    "title": "Boomy",
+    "description": "AI快速生成原创音乐的平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b57d6e8-9dcb-406c-87f8-2f8d95d8a208.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "afa44257-2769-4702-9c07-24722278d765"
+  },
+  {
+    "url": "https://typecast.ai/",
+    "title": "Typecast",
+    "description": "在线AI文字转语音生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ec8f1629-e60d-441f-b071-1af7de599a23.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "33d675d0-a971-4835-81a0-e31b0ee43267"
+  },
+  {
+    "url": "https://www.veed.io/tools/text-to-speech-video/ai-voice-generator",
+    "title": "Veed AI Voice Generator",
+    "description": "Veed推出的AI语音生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/25ebdc3e-af7e-42ca-9db0-9608626e5d58.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "a95377c8-de16-4556-a1bd-dcfd1906767c"
+  },
+  {
+    "url": "https://clipchamp.com/zh-hans/features/ai-voice-over-generator/",
+    "title": "Clipchamp AI旁白生成器",
+    "description": "Clipchamp的文字转语音生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/27496742-6f7f-4f37-8f50-9bc8e8010afa.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "3d458787-b5d7-4b86-af10-f23a928fdca3"
+  },
+  {
+    "url": "https://themetavoice.xyz/",
+    "title": "MetaVoice",
+    "description": "AI实时变声工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7e62024a-f4d7-41c5-ac43-64960bbe07f7.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "faf5a7a0-724c-4243-9dde-199efa6ec4e2"
+  },
+  {
+    "url": "https://speechify.com/zh-hans/",
+    "title": "Speechify",
+    "description": "超2000万人都在用的文字转语音朗读器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8f61d052-a270-451c-b665-047a1093737a.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "fc61d575-732e-489f-bedc-99e2f82143d2"
+  },
+  {
+    "url": "https://voicemaker.in/",
+    "title": "Voicemaker",
+    "description": "AI文本到语音生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c15fd280-b708-4fcb-b9d9-79f74b6f2356.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "fdd3095a-0594-480c-b0b1-26d730f01c5b"
+  },
+  {
+    "url": "https://voice.ai/",
+    "title": "Voice.ai",
+    "description": "实时AI变声工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/83b9b616-5d45-4f34-b630-b27898c1324b.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "85fd5ea5-d86c-4b2f-aa23-eebfd9afcb02"
+  },
+  {
+    "url": "https://www.listnr.tech/",
+    "title": "Listnr",
+    "description": "AI文本到语音生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cb882bf8-592a-49a5-b85f-402f90c1af87.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "d78e1f13-330a-4bdc-b5e5-09116f574147"
+  },
+  {
+    "url": "https://www.voicemod.net/ai-voices/",
+    "title": "Voicemod",
+    "description": "AI变声工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/7b05196b-1869-40d1-8d1f-03e80b683ec7.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "2bcdf6f1-eb05-479e-82f7-25add892e396"
+  },
+  {
+    "url": "https://wellsaidlabs.com/",
+    "title": "WellSaid Labs",
+    "description": "AI文本转语音工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/eb64cc73-54f2-43c7-93d9-d093e03bcda1.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "b4eb11de-d527-42ea-9209-69a8111e3590"
+  },
+  {
+    "url": "https://www.notta.ai/en",
+    "title": "Notta",
+    "description": "AI在线将语音转换成文字",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fe880cad-fb4e-4486-a70f-d6f7fa797ad6.png",
+    "category": [
+      "音频工具"
+    ],
+    "type": "web",
+    "id": "23e147bf-4117-46f9-8e35-0d8b9fe646b9"
+  },
+  {
+    "url": "https://logolivery.ai",
+    "title": "LogoliveryAI",
+    "description": "免费的AI Logo生成器，提供SVG矢量格式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/9210cdd5-6943-491f-815f-3841aea7bace.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "5c10500b-83ed-4057-bf5d-23a730ba2e18",
+    "type": "web"
+  },
+  {
+    "url": "https://motiff.com",
+    "title": "Motiff 妙多",
+    "description": "猿辅导旗下推出的AI界面设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/2b969971-367e-4146-9672-1fe3876b1248.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "9f209582-8635-4285-b951-a05f0e905ddf",
+    "type": "web"
+  },
+  {
+    "url": "https://www.pimento.design",
+    "title": "Pimento",
+    "description": "人工智能驱动的设计创意和视觉参考平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/77247ee2-066b-4ef9-a122-340c6da8e34d.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "c8d5b2d4-e6bb-4486-9834-d9db613a57ef",
+    "type": "web"
+  },
+  {
+    "url": "https://logodiffusion.com",
+    "title": "Logo Diffusion",
+    "description": "AI驱动的Logo和标志生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/612f17fe-ac13-4a8d-bb12-5aef7dc56f80.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "94b81fac-0789-4be6-9506-7989ce5339f3",
+    "type": "web"
+  },
+  {
+    "url": "https://www.realibox.com/product/ai",
+    "title": "Realibox AI",
+    "description": "AI免费将草图/模型生成3D渲染图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f7e25943-ec94-4ba4-965f-39260a5ec2e6.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "2ca0ea33-8bb9-4a05-9971-e8b9ab4b5d15",
+    "type": "web"
+  },
+  {
+    "url": "https://vectorizer.ai",
+    "title": "Vectorizer.AI",
+    "description": "AI一键将位图转换为矢量图片",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/b0e13ec0-5317-448c-9d40-e3e021e46c2a.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "2cc3a423-2b36-41c0-9347-ff10e24eae14",
+    "type": "web"
+  },
+  {
+    "url": "https://www.modaiyun.com/mdy/ai",
+    "title": "模袋云AI",
+    "description": "建筑AI创作平台，专注于大型建筑、小型住宅、室内设计、景观的出图和AI模型训练",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8005249f-830a-4c6c-8b82-404581c0594b.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "b8c289fb-6308-44b2-99e1-a5d939871c76",
+    "type": "web"
+  },
+  {
+    "url": "https://www.vizcom.ai/",
+    "title": "Vizcom",
+    "description": "AI渲染转化手绘图为产品设计图",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/5dec9b7d-7d4a-40ee-ba06-54414fa8ac40.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "88beaf46-76c5-417c-ac55-8ffb22347c85",
+    "type": "web"
+  },
+  {
+    "url": "https://www.dora.run/ai",
+    "title": "Dora AI",
+    "description": "AI在线生成精美3D动画的网站",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8dfba7a7-dc0e-4f57-9ed7-9bd9b5d7c8b8.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "ffc73a48-20e8-403b-8f7a-81864bab24de",
+    "type": "web"
+  },
+  {
+    "url": "https://designs.ai/",
+    "title": "Designs.ai",
+    "description": "AI设计工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4edf0fc6-2663-447a-bb66-f879e4b9555d.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "47359b1a-c504-40fe-979b-559b5fb1947d",
+    "type": "web"
+  },
+  {
+    "url": "https://www.usegalileo.ai/",
+    "title": "Galileo AI",
+    "description": "AI高保真原型设计",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f91c4c5d-f918-4038-9d0a-3af37b788c1b.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "e8ea717e-c946-48e5-a1c7-4e98d6593d54",
+    "type": "web"
+  },
+  {
+    "url": "https://spline.design/ai",
+    "title": "Spline AI",
+    "description": "Spline推出的AI生成3D物体、动画、材质",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/ff87ee1b-6258-4a36-aac3-f5ea341bc58f.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "b735e75c-64fe-4966-b751-39de84dd8673",
+    "type": "web"
+  },
+  {
+    "url": "https://hihaibao.com",
+    "title": "千图设计室AI海报",
+    "description": "免费批量生成在线可编辑的AI海报工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/e7f0e95e-5188-4dd5-845d-b19fda5ffdeb.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "8aa452c8-1b9b-4315-9b7a-8f8723f4335f",
+    "type": "web"
+  },
+  {
+    "url": "https://www.illostration.com/",
+    "title": "illostrationAI",
+    "description": "AI插画生成，low poly、3D、矢量、logo、像素风、皮克斯等风格",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/a6fef959-e7ce-4c78-879c-9fe9ac11fdb4.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "7373e997-9636-47ec-82f9-3bfabfae6204",
+    "type": "web"
+  },
+  {
+    "url": "https://uizard.io/ai-design/",
+    "title": "Uizard",
+    "description": "AI网页、App和UI设计，快速生成应用和网站原型",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f1fc0619-ed06-4472-8bad-73c979f9248c.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "8ff0f0b5-07da-4cc6-a7bc-8804ba075b44",
+    "type": "web"
+  },
+  {
+    "url": "https://lumalabs.ai/",
+    "title": "Luma AI",
+    "description": "AI 3D捕捉、建模和渲染",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/64c9a543-e511-4f9c-9e38-e64facb453fc.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "36c5e282-2964-4160-a8d7-eeca6b63e5bf",
+    "type": "web"
+  },
+  {
+    "url": "https://www.nolibox.com/introduction",
+    "title": "图宇宙",
+    "description": "高品质AI智能设计平台",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/760f3987-d71c-4c8b-b25c-88f16057ed90.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "70c0a0b4-0ed1-426d-8ad0-88b15b681af6",
+    "type": "web"
+  },
+  {
+    "url": "https://kebuxi.datasink.sensorsdata.cn/r/dF",
+    "title": "Fabrie AI",
+    "description": "在线白板协作平台Fabrie推出的AI设计助手，支持多种渲染模式",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/99aa6d14-9750-40ee-9f5a-b2c36abe8996.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "3aa959e5-63db-46df-a95f-56c41850d15d",
+    "type": "web"
+  },
+  {
+    "url": "https://withpoly.com/browse/textures",
+    "title": "Poly",
+    "description": "AI生成3D材质",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/28b4cffe-50a7-4f09-bcd6-3d269b308cda.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "73d76ae1-55c3-4ae0-abdf-92c1d0aa09c3",
+    "type": "web"
+  },
+  {
+    "url": "https://illustroke.com/",
+    "title": "Illustroke",
+    "description": "AI SVG矢量插画生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/1f932a9e-167c-42e3-bbaa-c90aa9e3b8fb.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "358f08ab-0b2e-451f-8a23-7be30e969a06",
+    "type": "web"
+  },
+  {
+    "url": "https://colors.eva.design/",
+    "title": "Eva Design System",
+    "description": "基于深度学习的色彩生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/53012d16-35f3-4c75-8697-2c41fa71d4e3.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "50bdf17d-dee8-4ada-802b-cc27a7f66f6f",
+    "type": "web"
+  },
+  {
+    "url": "https://brandmark.io/color-wheel/",
+    "title": "Color Wheel",
+    "description": "AI灰度logo或插画上色工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/4922f424-2baa-4395-a74c-007da04d14b0.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "37d0facd-5033-47e8-bca7-7f830ad06cd8",
+    "type": "web"
+  },
+  {
+    "url": "https://huemint.com/",
+    "title": "Huemint",
+    "description": "AI调色生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/810a54f5-303b-45a4-b06a-67b7fd66e754.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "1b635ccc-9e34-40c2-84d9-2c163eeb3934",
+    "type": "web"
+  },
+  {
+    "url": "https://www.obviously.ai/",
+    "title": "ColorMagic",
+    "description": "AI调色板生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/cca4be73-c13c-4bef-b70a-1f5320b3cfa4.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "7cd4bd5e-0108-4679-8da8-5ba125f1277f",
+    "type": "web"
+  },
+  {
+    "url": "https://logomaster.ai/",
+    "title": "Logomaster.ai",
+    "description": "AI Logo生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/d8db7439-311a-4664-870f-0ccbf453b38c.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "d12958d9-35a2-4e5c-949d-434f8353acfd",
+    "type": "web"
+  },
+  {
+    "url": "https://magician.design/",
+    "title": "Magician",
+    "description": "Figma插件，AI生成图标、图片和UX文案",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/8ced40a9-1a43-4fd1-b0ba-6f0da03ec5df.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "457f4519-1bf8-482d-97b6-29d95da89e5b",
+    "type": "web"
+  },
+  {
+    "url": "https://appicons.ai/",
+    "title": "Appicons AI",
+    "description": "AI生成精美App图标",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/c0efc05e-a569-4d20-8517-aa9eedd83d2a.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "85f69aa2-623e-4022-aa71-ad74a586bc9b",
+    "type": "web"
+  },
+  {
+    "url": "https://www.iconifyai.com/",
+    "title": "IconifyAI",
+    "description": "AI App图标生成器",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/71cde335-b43d-49ae-8d4e-3ad42337f2ed.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "9e60ba85-fee0-4955-bc6b-1ea174661b6f",
+    "type": "web"
+  },
+  {
+    "url": "https://www.khroma.co/",
+    "title": "Khroma",
+    "description": "AI调色盘生成工具",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/20d664f2-1502-4f2d-aab0-7e2ee96dd1fe.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "d04b1630-71e8-469e-b125-34913bc923ef",
+    "type": "web"
+  },
+  {
+    "url": "https://jsai.cc/ai/create",
+    "title": "即时AI",
+    "description": "即时设计推出的由文本描述生成可编辑的原型设计稿",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/f781f121-206d-4ea9-90b8-762089e3c489.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "1f4e55eb-3efd-4c96-b6f5-08c75b501d1f",
+    "type": "web"
+  },
+  {
+    "url": "https://www.getalpaca.io",
+    "title": "Alpaca",
+    "description": "将生成式AI集成到Photoshop图像设计中",
+    "image": "https://cdn.fanquanpintuan.cn/deepopen/avatar/fb6f0a41-37c9-4d77-9a11-2caa5a900c03.png",
+    "category": [
+      "设计工具"
+    ],
+    "id": "294c5806-6ed8-4e8f-91cb-572dfb839f0e",
+    "type": "web"
+  },
+  {
+    "url": "https://www.aurcue.com",
+    "description": "AI个人美学助手，根据一张照片生成个人色彩、穿搭、发型和眼镜建议",
+    "image": "https://www.aurcue.com/brand/logo-h-transparent.png",
+    "category": [
+      "图像工具",
+      "设计工具"
+    ],
+    "id": "db99d6a1-94cd-4fd5-b894-9953dfd25b9b",
+    "title": "Aurcue",
+    "type": "web"
+  },
+  {
+    "url": "https://remio.ai/",
+    "description": "本地优先的AI记忆和知识库，支持多格式内容索引与语义检索",
+    "image": "https://remio.ai/favicon.ico",
+    "category": [
+      "文档工具"
+    ],
+    "id": "b70bbaaf-cebc-4428-b971-3ff2389afea8",
+    "title": "Remio",
+    "type": "web"
+  },
+  {
+    "url": "https://wizgenerator.com/tools/story-generator/",
+    "description": "免费AI故事生成工具，可根据主题、类型、语气和篇幅生成故事草稿，无需注册",
+    "image": "https://wizgenerator.com/wp-content/uploads/2024/06/cropped-WizGenerator-Icon-192x192.png",
+    "category": [
+      "文档工具"
+    ],
+    "id": "071a3525-cc75-4508-a307-7368d8727dcf",
+    "title": "WizGenerator Story Generator",
+    "type": "web"
+  }
 ]


### PR DESCRIPTION
Adds Lunalisa (https://luna-lisa.art) to data.json and README.md under the 商品图生成 (Product Image Generation) category — an AI creative workspace for product photos, marketing posters, and white-background listing images across 13 image models and 22 video models (Nano Banana, Seedream, Kling, Veo).