### PR TITLE
Track referrals from the LuckyAPI listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@
 | CodeFuse | web | 蚂蚁集团推出的AI代码编程助手 | [官网](https://codefuse.alipay.com) |
 | Tabby | web | 免费开源的自托管AI编程助手 | [官网](https://tabby.tabbyml.com) |
 | TeamoRouter | web | Claude Code/Codex LLM API 智能路由网关，一个Key接入所有主流模型，微信支付宝充值 | [官网](https://teamorouter.com?utm_source=github&utm_medium=issue&utm_campaign=round3&utm_content=awesome-ai-tools-cn) |
-| LuckyAPI | web | 多模型 API 网关，一个 Key 接入 OpenAI、Anthropic、Google 和 xAI 兼容接口，并提供实时模型目录与定价 | [官网](https://luckyapi.online/zh-cn) |
+| LuckyAPI | web | 多模型 API 网关，一个 Key 接入 OpenAI、Anthropic、Google 和 xAI 兼容接口，并提供实时模型目录与定价 | [官网](https://argolink.io/zh-cn?utm_source=github&utm_medium=resource-list&utm_campaign=gh-rvelamen-awesome-ai-tools-pr-54) |
 | C知道 | web | CSDN推出的AI技术问答工具 | [官网](https://so.csdn.net/chat) |
 | 驭码CodeRider | web | 极狐GitLab推出的AI编程与软件智能研发助手 | [官网](https://coderider.gitlab.cn) |
 | Duo Chat | web | GitLab推出的AI编程助手 | [官网](https://about.gitlab.com/gitlab-duo) |

--- a/data.json
+++ b/data.json
@@ -4200,7 +4200,7 @@
     "id": "860737f6-e036-438e-87f6-2e963e5f402a"
   },
   {
-    "url": "https://luckyapi.online/zh-cn",
+    "url": "https://argolink.io/zh-cn?utm_source=github&utm_medium=resource-list&utm_campaign=gh-rvelamen-awesome-ai-tools-pr-54",
     "title": "LuckyAPI",
     "description": "多模型 API 网关，一个 Key 接入 OpenAI、Anthropic、Google 和 xAI 兼容接口，并提供实时模型目录与定价",
     "image": "https://luckyapi.online/app/assets/site-mark.png",


### PR DESCRIPTION
## Summary

- update the already merged LuckyAPI listing to use its dedicated GitHub resource-list campaign URL
- keep `README.md` and `data.json` synchronized
- preserve the existing description, category, and image

## Why

The listing was merged in #54 before its referral URL update reached the pull request. This follow-up changes only the destination URL so referrals from this list can be measured separately from other GitHub placements.

## Verification

- `jq empty data.json`
- checked for duplicate catalog IDs
- confirmed the README and `data.json` LuckyAPI URLs match
- confirmed exactly one LuckyAPI entry exists in each source
- checked trailing whitespace
- verified the tracked URL returns HTTP 200

## Disclosure

Submitted by a LuckyAPI maintainer. The URL contains aggregate campaign parameters only; it has no user identifier, credential, or affiliate code.
