### PR TITLE
Add WSUP AI: Free AI Character Chat

### DIFF
--- a/data.json
+++ b/data.json
@@ -17244,5 +17244,16 @@
     "id": "743532ba-b724-4c51-9475-cc733275df88",
     "title": "Pippit",
     "type": "web"
+  },
+  {
+    "url": "https://wsupai.app/",
+    "title": "WSUP AI",
+    "type": "web",
+    "description": "浏览器内免费 AI 角色聊天，无需注册，仅限 SFW",
+    "image": "https://wsupai.app/apple-touch-icon.png",
+    "category": [
+      "聊天助手"
+    ],
+    "id": "a3fef073-05af-4c8e-9d5f-4232b5e51eec"
   }
 ]


### PR DESCRIPTION
## Summary
Add **WSUP AI: Free AI Character Chat** to the 聊天助手 via data.json section.

## Product
- **Name:** WSUP AI: Free AI Character Chat
- **URL:** https://wsupai.app/
- **Description:** Free AI character chat in the browser — talk to AI characters with no sign up. SFW only.

## Affiliation
I am affiliated with WSUP AI / Ownland (maintainer submitting this listing).

## Notes
- One product per PR
- Matched neighbor formatting in the target section
- SFW-only character chat product
